### PR TITLE
fetchgit -> fetchFromGitHub to pull in nixpkgs

### DIFF
--- a/nixpkgs/default.nix
+++ b/nixpkgs/default.nix
@@ -1,1 +1,1 @@
-import ((import <nixpkgs> {}).fetchgit (import ./git.nix))
+import ((import <nixpkgs> {}).fetchFromGitHub (import ./git.nix))

--- a/nixpkgs/git.nix
+++ b/nixpkgs/git.nix
@@ -1,5 +1,10 @@
 {
-  url = git://github.com/NixOS/nixpkgs-channels;
+  owner = "nixos";
+
+  # Could also just be nixpkgs. However this makes it clearer that we
+  # intend to use a revision that benefits from the binary cache.
+  repo = "nixpkgs-channels";
+
   rev = "cd7242d09d64669c05246a4005731b1fa1cbaa15";
-  sha256 = "1rfigiipqsnbj4grg05ch9anaa0kc1aawfic5h10h6rlpgslrrhf";
+  sha256 = "0ivnkbn6w969m5dmavy0yj0fgbznabc3krw1nh05pqf2anhn6p12";
 }


### PR DESCRIPTION
This provides a significant reduction in network IO, since we download a
14MiB tar.gz instead of 400+ MiB worth of git objects.

tested with `cd reflex-platform; nix-shell nixpkgs/`
