### PR TITLE
Skip Glob's testsuite

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -120,11 +120,11 @@ let overrideCabal = pkg: f: if pkg == null then null else lib.overrideCabal pkg 
           libraryHaskellDepends = drv.libraryHaskellDepends ++ [ self.mtl self.mwc-random ];
         });
 
-        Glob = overrideCabal super.Glob (drv: {
-          libraryHaskellDepends = drv.libraryHaskellDepends ++ [ self.semigroups ];
-        });
-
         # Failing tests
+        Glob = dontCheck (overrideCabal super.Glob (drv: {
+          libraryHaskellDepends = drv.libraryHaskellDepends ++ [ self.semigroups ];
+        }));
+
         ed25519 = dontCheck super.ed25519;
         git = dontCheck super.git;
 


### PR DESCRIPTION
Add Glob to broken-tests list. Otherwise (using work-on, osx):

```
Preprocessing test suite 'glob-tests' for Glob-0.7.10...

Tests/Utils.hs:3:8: error:
    File name does not match module name:
    Saw: ‘Utils’
    Expected: ‘Tests.Utils’
builder for ‘/nix/store/69ggby4nz4syz4986pvv1g5xdhs1rfqp-Glob-0.7.10.drv’ failed with exit code 1
```