### PR TITLE
Update the tutorial to follow the latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ In this example, we'll be following [Luite Stegemann's lead](http://weblog.luite
 Reflex's companion library, Reflex-DOM, contains a number of functions used to build and interact with the Document Object Model. Let's start by getting a basic app up and running.
 
 ```haskell
+{-# LANGUAGE OverloadedStrings #-}
 import Reflex.Dom
 
 main = mainWidget $ el "div" $ text "Welcome to Reflex"
@@ -65,10 +66,10 @@ Most Reflex apps will start the same way: a call to `mainWidget` with a starting
 `el` has the type signature:
 
 ```haskell
-el :: MonadWidget t m => String -> m a -> m a
+el :: MonadWidget t m => Text -> m a -> m a
 ```
 
-The first argument to `el` is a `String`, which will become the tag of the html element produced. The second argument is a `Widget`, which will become the child of the element being produced.
+The first argument to `el` is a `Text`, which will become the tag of the html element produced. The second argument is a `Widget`, which will become the child of the element being produced.
 
 > #### Sidebar: Interpreting the MonadWidget type
 > FRP-enabled datatypes in Reflex take an argument `t`, which identifies the FRP subsystem being used.  This ensures that wires don't get crossed if a single program uses Reflex in multiple different contexts.  You can think of `t` as identifying a particular "timeline" of the FRP system.
@@ -79,12 +80,13 @@ In our example, `el "div" $ text "Welcome to Reflex"`, the first argument to `el
 The second argument to `el` was `text "Welcome to Reflex"`. The type signature of `text` is:
 
 ```haskell
-text :: MonadWidget t m => String -> m ()
+text :: MonadWidget t m => Text -> m ()
 ```
 
-`text` takes a `String` and produces a `Widget`. The `String` becomes a text DOM node in the parent element of the `text`. Of course, instead of a `String`, we could have used `el` here as well to continue building arbitrarily complex DOM. For instance, if we wanted to make a unordered list:
+`text` takes a `Text` and produces a `Widget`. The `Text` becomes a text DOM node in the parent element of the `text`. Of course, instead of a `Text`, we could have used `el` here as well to continue building arbitrarily complex DOM. For instance, if we wanted to make a unordered list:
 
 ```haskell
+{-# LANGUAGE OverloadedStrings #-}
 import Reflex.Dom
 
 main = mainWidget $ el "div" $ do
@@ -99,6 +101,7 @@ main = mainWidget $ el "div" $ do
 Of course, we want to do more than just view a static webpage. Let's start by getting some user input and printing it.
 
 ```haskell
+{-# LANGUAGE OverloadedStrings #-}
 import Reflex.Dom
 
 main = mainWidget $ el "div" $ do
@@ -118,32 +121,35 @@ It takes a `TextInputConfig` (given a default value in our example), and produce
 
 ```haskell
 data TextInput t
-   = TextInput { _textInput_value :: Dynamic t String
+   = TextInput { _textInput_value :: Dynamic t Text
+               , _textInput_input :: Event t Text
                , _textInput_keypress :: Event t Int
                , _textInput_keydown :: Event t Int
                , _textInput_keyup :: Event t Int
                , _textInput_hasFocus :: Dynamic t Bool
-               , _textInput_element :: HTMLInputElement
+               , _textInput_builderElement :: InputElement EventResult GhcjsDomSpace t
                }
 ```
 
-Here we are using `_textInput_value` to access the `Dynamic String` value of the `TextInput`. Conveniently, `dynText` takes a `Dynamic String` and displays it. It is the dynamic version of `text`.
+Here we are using `_textInput_value` to access the `Dynamic Text` value of the `TextInput`. Conveniently, `dynText` takes a `Dynamic Text` and displays it. It is the dynamic version of `text`.
 
 We can also access `Event`s related to the `TextInput`. For example, consider the following code:
 
 ```haskell
+{-# LANGUAGE OverloadedStrings #-}
+import Data.Text  (pack)
 import Reflex
 import Reflex.Dom
 
 main = mainWidget $ el "div" $ do
   t <- textInput def
   text "Last key pressed: "
-  let keypressEvent = fmap show $ _textInput_keypress t
+  let keypressEvent = fmap (pack . show) $ _textInput_keypress t
   keypressDyn <- holdDyn "None" keypressEvent
   dynText keypressDyn
 ```
 
-Here, we are creating a `TextInput` as we were before. The function `_textInput_keypress` gives us an `Event Int` representing the key code of the pressed key. We are using `fmap` here to apply `show` to the `Int`, so the type of `keypressEvent` is `Event String`. Whenever a key is pressed inside the `TextInput`, the `keypressEvent` will fire.
+Here, we are creating a `TextInput` as we were before. The function `_textInput_keypress` gives us an `Event Int` representing the key code of the pressed key. We are using `fmap` here to apply `pack . show` to the `Int`, so the type of `keypressEvent` is `Event Text`. Whenever a key is pressed inside the `TextInput`, the `keypressEvent` will fire.
 `holdDyn` allows us to take create a `Dynamic` out of an `Event`. We must provide an initial value for the `Dynamic`. This will be the value of the `Dynamic` until the associated `Event` fires. The type of `holdDyn` is:
 
 ```haskell
@@ -158,6 +164,7 @@ When you run this application, you'll see a textbox and the string "Last key pre
 A calculator was promised, I know. We'll start building the calculator by creating an input for numbers.
 
 ```haskell
+{-# LANGUAGE OverloadedStrings #-}
 import Reflex
 import Reflex.Dom
 import qualified Data.Map as Map
@@ -168,31 +175,32 @@ main = mainWidget $ el "div" $ do
   dynText $ _textInput_value t
 ```
 
-The code above overrides some of the default values of the `TextInputConfig`. We provide a `String` value for the `textInputConfig_inputType`, specifying the html input element's `type` attribute. We're using `"number"` here.
+The code above overrides some of the default values of the `TextInputConfig`. We provide a `Text` value for the `textInputConfig_inputType`, specifying the html input element's `type` attribute. We're using `"number"` here.
 
-Next, we override the default initial value of the `TextInput`. We gave it `"0"`. Even though we're making an html `input` element with the attribute `type=number`, the result is still a `String`. We'll convert this later.
+Next, we override the default initial value of the `TextInput`. We gave it `"0"`. Even though we're making an html `input` element with the attribute `type=number`, the result is still a `Text`. We'll convert this later.
 
 Let's do more than just take the input value and print it out. First, let's make sure the input is actually a number:
 
 ```haskell
-import Reflex
+{-# LANGUAGE OverloadedStrings #-}
 import Reflex.Dom
 import qualified Data.Map as Map
-import Safe (readMay)
+import Safe      (readMay)
+import Data.Text (pack, unpack)
 
 main = mainWidget $ el "div" $ do
   x <- numberInput
-  numberString <- mapDyn show x
+  let numberString = fmap (pack . show) x
   dynText numberString
 
 numberInput :: MonadWidget t m => m (Dynamic t (Maybe Double))
 numberInput = do
   n <- textInput $ def & textInputConfig_inputType .~ "number"
                        & textInputConfig_initialValue .~ "0"
-  mapDyn readMay $ _textInput_value n
+  return . fmap (readMay . unpack) $ _textInput_value n
 ```
 
-We've defined a function `numberInput` that both handles the creation of the `TextInput` and reads its value. Recall that `_textInput_value` gives us a `Dynamic String`. The final line of code in `numberInput` uses `mapDyn` to apply the function `readMay` to the `Dynamic` value of the `TextInput`. This produces a `Dynamic (Maybe Double)`. Our `main` function uses `mapDyn` to map over the `Dynamic (Maybe Double)` produced by `numberInput` and `show` the value it contains. We store the new `Dynamic String` in `numberString` and feed that into `dynText` to actually display the `String`
+We've defined a function `numberInput` that both handles the creation of the `TextInput` and reads its value. Recall that `_textInput_value` gives us a `Dynamic Text`. The final line of code in `numberInput` uses `fmap` to apply the function `readMay . unpack` to the `Dynamic` value of the `TextInput`. This produces a `Dynamic (Maybe Double)`. Our `main` function uses `fmap` to map over the `Dynamic (Maybe Double)` produced by `numberInput` and `pack . show` the value it contains. We store the new `Dynamic Text` in `numberString` and feed that into `dynText` to actually display the `Text`
 
 Running the app at this point should produce an input and some text showing the `Maybe Double`. Typing in a number should produce output like `Just 12.0` and typing in other text should produce the output `Nothing`.
 
@@ -200,10 +208,12 @@ Running the app at this point should produce an input and some text showing the 
 Now that we have `numberInput` we can put together a couple inputs to make a basic calculator.
 
 ```haskell
+{-# LANGUAGE OverloadedStrings #-}
 import Reflex
 import Reflex.Dom
 import qualified Data.Map as Map
-import Safe (readMay)
+import Safe      (readMay)
+import Data.Text (pack, unpack)
 import Control.Applicative ((<*>), (<$>))
 
 main = mainWidget $ el "div" $ do
@@ -211,37 +221,37 @@ main = mainWidget $ el "div" $ do
   text " + "
   ny <- numberInput
   text " = "
-  result <- combineDyn (\x y -> (+) <$> x <*> y) nx ny
-  resultString <- mapDyn show result
+  let result = zipDynWith (\x y -> (+) <$> x <*> y) nx ny
+      resultString = fmap (pack . show) result
   dynText resultString
 
 numberInput :: MonadWidget t m => m (Dynamic t (Maybe Double))
 numberInput = do
   n <- textInput $ def & textInputConfig_inputType .~ "number"
                        & textInputConfig_initialValue .~ "0"
-  mapDyn readMay $ _textInput_value n
+  return . fmap (readMay . unpack) $ _textInput_value n
 ```
 
-`numberInput` hasn't changed here. Our `main` function now creates two inputs. `combineDyn` is used to produce the actual sum of the values of the inputs. The type signature of `combineDyn` is:
+`numberInput` hasn't changed here. Our `main` function now creates two inputs. `zipDynWith` is used to produce the actual sum of the values of the inputs. The type signature of `zipDynWith` is:
 
 ```haskell
-    (Reflex t, MonadHold t m) => (a -> b -> c) -> Dynamic t a -> Dynamic t b -> m (Dynamic t c)
+    Reflex t => (a -> b -> c) -> Dynamic t a -> Dynamic t b -> Dynamic t c 
 ```
 
 You can see that it takes a function that combines two pure values and produces some other pure value, and two `Dynamic`s, and produces a `Dynamic`.
 
-In our case, `combineDyn` is combining the results of our two `numberInput`s (with a little help from `Control.Applicative`) into a sum.
+In our case, `zipDynWith` is combining the results of our two `numberInput`s (with a little help from `Control.Applicative`) into a sum.
 
-We use `mapDyn` again to apply show to `result` (a `Dynamic (Maybe Double)`) resulting in a `Dynamic String`. This `resultString` is then displaying using `dynText`.
+We use `fmap` again to apply `pack . show` to `result` (a `Dynamic (Maybe Double)`) resulting in a `Dynamic Text`. This `resultText` is then displayed using `dynText`.
 
 ### Supporting Multiple Operations
 Next, we'll add support for other operations. We're going to add a dropdown so that the user can select the operation to apply. The function `dropdown` has the type:
 
 ```haskell
-dropdown :: (MonadWidget t m, Ord k, Show k, Read k) => k -> Dynamic t (Map k String) -> DropdownConfig t k -> m (Dropdown t k)
+dropdown :: (MonadWidget t m, Ord k) => k -> Dynamic t (Map k Text) -> DropdownConfig t k -> m (Dropdown t k)
 ```
 
-The first argument is the initial value of the `Dropdown`. The second argument is a `Dynamic (Map k String)` that represents the options in the dropdown. The `String` values of the `Map` are the strings that will be displayed to the user. If the initial key is not in the `Map`, it is added and given a `String` value of `""`. The final argument is a `DropdownConfig`.
+The first argument is the initial value of the `Dropdown`. The second argument is a `Dynamic (Map k Text)` that represents the options in the dropdown. The `Text` values of the `Map` are the strings that will be displayed to the user. If the initial key is not in the `Map`, it is added and given a `Text` value of `""`. The final argument is a `DropdownConfig`.
 
 Our supported operations will be:
 
@@ -258,42 +268,45 @@ d <- dropdown "*" (constDyn ops) def
 We are using `constDyn` again here to turn our `Map` of operations into a `Dynamic`. Using `def`, we provide the default `DropdownConfig`. The result, `d`, will be a `Dropdown`. We can retrieve the `Dynamic` selection of a `Dropdown` by using `_dropdown_value`.
 
 ```haskell
+{-# LANGUAGE OverloadedStrings #-}
 import Reflex
 import Reflex.Dom
 import qualified Data.Map as Map
-import Safe (readMay)
+import Safe      (readMay)
+import Data.Text (pack, unpack, Text)
 import Control.Applicative ((<*>), (<$>))
 
 main = mainWidget $ el "div" $ do
   nx <- numberInput
   d <- dropdown "*" (constDyn ops) def
   ny <- numberInput
-  values <- combineDyn (,) nx ny
-  result <- combineDyn (\o (x,y) -> stringToOp o <$> x <*> y) (_dropdown_value d) values
-  resultString <- mapDyn show result
+  let values = zipDynWith (,) nx ny
+      result = zipDynWith (\o (x,y) -> textToOp o <$> x <*> y) (_dropdown_value d) values
+      resultText = fmap (pack . show) result
   text " = "
-  dynText resultString
+  dynText resultText
 
 numberInput :: MonadWidget t m => m (Dynamic t (Maybe Double))
 numberInput = do
   n <- textInput $ def & textInputConfig_inputType .~ "number"
                        & textInputConfig_initialValue .~ "0"
-  mapDyn readMay $ _textInput_value n
+  return . fmap (readMay . unpack) $ _textInput_value n
 
 ops = Map.fromList [("+", "+"), ("-", "-"), ("*", "*"), ("/", "/")]
 
-stringToOp s = case s of
+textToOp :: (Fractional a) => Text -> a -> a -> a
+textToOp s = case s of
                     "-" -> (-)
                     "*" -> (*)
                     "/" -> (/)
                     _ -> (+)
 ```
 
-This is our complete program. We've added an uninteresting function `stringToOp` that takes a `String` and returns an operation. The keys of the `Map` we used to create the `Dropdown` had the type `String`. When we retrieve the value of `Dropdown`, we'll use `stringToOp` to turn the `Dropdown` selection into the function we need to apply to our numbers.
+This is our complete program. We've added an uninteresting function `textToOp` that takes a `Text` and returns an operation. The keys of the `Map` we used to create the `Dropdown` had the type `Text`. When we retrieve the value of `Dropdown`, we'll use `TextToOp` to turn the `Dropdown` selection into the function we need to apply to our numbers.
 
-After creating the two `numberInput`s, we combine them using `combineDyn` applying `(,)`, making a tuple of type `Dynamic (Maybe Double, Maybe Double)` and binding it to `values`.
+After creating the two `numberInput`s, we combine them using `zipDynWith` applying `(,)`, making a tuple of type `Dynamic (Maybe Double, Maybe Double)` and binding it to `values`.
 
-Next, we call `combineDyn` again, combining the `_dropdown_value` and `values`. Now, instead of applying `(+)` to our `Double` values, we use `stringToOp` to select an operation based on the `Dynamic` value of our `Dropdown`.
+Next, we call `zipDynWith` again, combining the `_dropdown_value` and `values`. Now, instead of applying `(+)` to our `Double` values, we use `textToOp` to select an operation based on the `Dynamic` value of our `Dropdown`.
 
 Running the app at this point will give us our two number inputs with a dropdown of operations sandwiched between them. Multiplication should be pre-selected when the page loads.
 
@@ -305,7 +318,7 @@ numberInput :: MonadWidget t m => m (Dynamic t (Maybe Double))
 numberInput = do
   n <- textInput $ def & textInputConfig_inputType .~ "number"
                        & textInputConfig_initialValue .~ "0"
-  mapDyn readMay $ _textInput_value n
+  return . fmap (readMay . unpack) $ _textInput_value n
 ```
 
 Let's give it some html attributes to work with:
@@ -313,15 +326,14 @@ Let's give it some html attributes to work with:
 ```haskell
 numberInput :: MonadWidget t m => m (Dynamic t (Maybe Double))
 numberInput = do
-  let attrs = constDyn $ Map.fromList [("style", "border-color: blue")]
+  let attrs = constDyn ("style" =: "border-color: blue")
   n <- textInput $ def & textInputConfig_inputType .~ "number"
                        & textInputConfig_initialValue .~ "0"
                        & textInputConfig_attributes .~ attrs
-  mapDyn readMay $ _textInput_value n
-
+  return . fmap (readMay . unpack) $ _textInput_value n
 ```
 
-Here, we've created a `Dynamic (Map String String)`. This `Map` represents the html attributes of our inputs. Because we're using `constDyn` again, this `Dynamic` will never change. If you load this in the browser, you'll see that the inputs now have a blue border.
+Here, we've created a `Dynamic (Map Text Text)`. This `Map` represents the html attributes of our inputs. Because we're using `constDyn` again, this `Dynamic` will never change. If you load this in the browser, you'll see that the inputs now have a blue border.
 
 Unchanging attributes are useful and quite common, but attributes will often need to change. Instead of just making the `TextInput` blue, let's change it's color based on whether the input successfully parses to a `Double`:
 
@@ -330,64 +342,63 @@ Unchanging attributes are useful and quite common, but attributes will often nee
 ...
 numberInput :: (MonadWidget t m) => m (Dynamic t (Maybe Double))
 numberInput = do
-  let errorState = Map.singleton "style" "border-color: red"
-      validState = Map.singleton "style" "border-color: green"
+  let errorState = "style" =: "border-color: red"
+      validState = "style" =: "border-color: green"
   rec n <- textInput $ def & textInputConfig_inputType .~ "number"
                            & textInputConfig_initialValue .~ "0"
                            & textInputConfig_attributes .~ attrs
-      result <- mapDyn readMay $ _textInput_value n
-      attrs <- mapDyn (\r -> case r of
-                                  Just _ -> validState
-                                  Nothing -> errorState) result
+      let result = fmap (readMay . unpack) $ _textInput_value n
+          attrs  = fmap (maybe errorState (const validState)) result
   return result
 ```
 
 Note that we need to add a language pragma here to enable the `RecursiveDo` language extension. We've defined two `Map`s of attributes for our inputs: one to represent bad input and one to represent valid input. Next, you'll see that the code for actually making the number input is now inside of a `rec` block. This is because the attributes we apply depend on the value of the input.
 
-In the first line of the `rec`, we have supplied the argument `attrs`, of type `Dynamic (Map String String)`. The `Dynamic` value of the input is bound to `result`. The code for parsing this value has not changed.
+In the first line of the `rec`, we have supplied the argument `attrs`, of type `Dynamic (Map Text Text)`. The `Dynamic` value of the input is bound to `result`. The code for parsing this value has not changed.
 
-After we bind `result`, we use `mapDyn` again to apply a switching function to `result`. The switching function checks whether the value was successfully parsed. If it was, we get the `Map` of attributes representing the valid state, otherwise we get the `Map` representing the error state. The result is a `Dynamic (Map String String)`, which is the type `textInputConfig_attributes` expects to receive.
+After we bind `result`, we use `fmap` again to apply a switching function to `result`. The switching function checks whether the value was successfully parsed. If it was, we get the `Map` of attributes representing the valid state, otherwise we get the `Map` representing the error state. The result is a `Dynamic (Map Text Text)`, which is the type `textInputConfig_attributes` expects to receive.
 
 The complete program now looks like this:
 
 ```haskell
-{-# LANGUAGE RecursiveDo #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecursiveDo       #-}
 import Reflex
 import Reflex.Dom
 import qualified Data.Map as Map
-import Safe (readMay)
+import Safe      (readMay)
+import Data.Text (pack, unpack, Text)
 import Control.Applicative ((<*>), (<$>))
 
 main = mainWidget $ el "div" $ do
   nx <- numberInput
   d <- dropdown "*" (constDyn ops) def
   ny <- numberInput
-  values <- combineDyn (,) nx ny
-  result <- combineDyn (\o (x,y) -> stringToOp o <$> x <*> y) (_dropdown_value d) values
-  resultString <- mapDyn show result
+  let values = zipDynWith (,) nx ny
+      result = zipDynWith (\o (x,y) -> textToOp o <$> x <*> y) (_dropdown_value d) values
+      resultText = fmap (pack . show) result
   text " = "
-  dynText resultString
+  dynText resultText
 
 numberInput :: (MonadWidget t m) => m (Dynamic t (Maybe Double))
 numberInput = do
-  let errorState = Map.singleton "style" "border-color: red"
-      validState = Map.singleton "style" "border-color: green"
+  let errorState = "style" =: "border-color: red"
+      validState = "style" =: "border-color: green"
   rec n <- textInput $ def & textInputConfig_inputType .~ "number"
-                       & textInputConfig_initialValue .~ "0"
-                       & textInputConfig_attributes .~ attrs
-      result <- mapDyn readMay $ _textInput_value n
-      attrs <- mapDyn (\r -> case r of
-                                  Just _ -> validState
-                                  Nothing -> errorState) result
+                           & textInputConfig_initialValue .~ "0"
+                           & textInputConfig_attributes .~ attrs
+      let result = fmap (readMay . unpack) $ _textInput_value n
+          attrs  = fmap (maybe errorState (const validState)) result
   return result
 
-stringToOp s = case s of
-                      "-" -> (-)
-                      "*" -> (*)
-                      "/" -> (/)
-                      _ -> (+)
-
 ops = Map.fromList [("+", "+"), ("-", "-"), ("*", "*"), ("/", "/")]
+
+textToOp :: (Fractional a) => Text -> a -> a -> a
+textToOp s = case s of
+                    "-" -> (-)
+                    "*" -> (*)
+                    "/" -> (/)
+                    _ -> (+)
 ```
 
 The input border colors will now change depending on their value.


### PR DESCRIPTION
The problem which have been corrected here are:

1) Many function which required or returned `String` require or return
`Text` now. I fixed these instances both in the code and in the text.

2) In the last version there was a deprecation of some of the monadic
functions in the interface, like `mapDyn` or `combineDyn` in favour of
`fmap` and `zipDynWith`. Again, this has been fixed both in the code and
in the text of the tutorial.

I actually typechecked all the new fragments to make sure they
typecheck, but I might have missed something, so please double-check.