### PR TITLE
Fix stage2.nix generation

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -304,7 +304,7 @@ in let this = rec {
   ghc7_8 = overrideForGhc7_8 (extendHaskellPackages nixpkgs.pkgs.haskell.packages.ghc784);
   stage2Script = nixpkgs.runCommand "stage2.nix" {
     buildCommand = ''
-      ${nixpkgs.path}/pkgs/development/compilers/ghcjs/gen-stage2.rb "${sources.ghcjs-boot}" >"$out"
+      ruby ${nixpkgs.path}/pkgs/development/compilers/ghcjs/gen-stage2.rb "${sources.ghcjs-boot}" >"$out"
     '';
     buildInputs = with nixpkgs; [
       ruby cabal2nix


### PR DESCRIPTION
I was getting a build error on nixos-unstable (0c6b3a3). This change makes the stage2.nix regeneration script run with the ruby interpreter provided by buildInputs.
