### PR TITLE
Added Docker and Vagrant setup for try-reflex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ reflex-dom/*
 reflex-todomvc/*
 !reflex-todomvc/default.nix
 !reflex-todomvc/github.json
+
+# Dev tools
+.vagrant

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM debian:jessie
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 575159689BEFB442
+RUN echo 'deb http://download.fpcomplete.com/debian jessie main' | \
+    tee /etc/apt/sources.list.d/fpco.list
+RUN apt-get update -y && apt-get upgrade -y && apt-get install -y \
+    curl bzip2 build-essential zlib1g zlib1g-dev stack libtinfo-dev libncurses5-dev libncursesw5-dev
+ENV U robot
+RUN useradd -ms /bin/bash $U
+RUN groupadd nixbld && usermod -a -G nixbld $U
+ENV HOME /home/$U
+RUN mkdir -p /nix /opt/reflex-platform && chown -R $U /nix /opt/reflex-platform
+ENV USER $U
+USER $U
+WORKDIR /home/$U
+RUN curl https://nixos.org/nix/install | sh
+RUN . $HOME/.nix-profile/etc/profile.d/nix.sh && \
+    nix-channel --add https://nixos.org/channels/nixpkgs-unstable && \
+    nix-channel --update
+RUN echo ". $HOME/.nix-profile/etc/profile.d/nix.sh" >> ~/.bashrc
+WORKDIR /opt/reflex-platform
+ADD . ./
+USER root
+RUN chown -R $U ./
+USER $U

--- a/README.md
+++ b/README.md
@@ -44,6 +44,23 @@ This process will install the [Nix package manager](https://nixos.org/nix/). If 
 
 5. If you need to add any additional dependencies, edit `packages.nix`, then exit and re-enter the try-reflex shell.  **Don't use** `cabal install` to install libraries while inside the try-reflex shell - the resulting libraries may not be found properly by ghc or ghcjs.  Using Cabal to configure, build, test, and run a particular package, however, should work just fine.
 
+*Notes (For Vagrant and Docker)*
+
+It is also possible to use [Vagrant](https://www.vagrantup.com) and/or [Docker](https://www.docker.com) to try reflex. To get setup with vagrant, simply run:
+
+```bash
+vagrant up
+vagrant ssh
+./try-reflex
+```
+
+Or using Docker:
+
+```bash
+docker-compose build
+docker-compose up -d
+```
+
 Tutorial
 --------
 In this example, we'll be following [Luite Stegemann's lead](http://weblog.luite.com/wordpress/?p=127) and building a simple functional reactive calculator to be used in a web browser.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,37 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby:
+
+$script = <<SCRIPT
+U=vagrant
+apt-get update -y
+apt-get install -y apt-transport-https ca-certificates curl
+apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 \
+    --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+echo "deb https://apt.dockerproject.org/repo ubuntu-trusty main" | \
+    tee /etc/apt/sources.list.d/docker.list
+apt-get update -y
+apt-cache policy docker-engine
+apt-get install -y docker-engine
+service docker start
+gpasswd -a $U docker
+sudo curl -o /usr/local/bin/docker-compose -L \
+    "https://github.com/docker/compose/releases/download/1.9.0/docker-compose-$(uname -s)-$(uname -m)"
+chmod +x /usr/local/bin/docker-compose
+chown -R $U /usr/local/bin/docker-compose
+echo "cd /opt/reflex-platform" >> /home/$U/.bashrc
+exit 0
+SCRIPT
+
+Vagrant.configure(2) do |config|
+    config.vm.box = "minimal/trusty64"
+    config.vm.hostname = "reflex-platform.vagrant"
+    config.vm.network "private_network", ip: "192.168.50.42"
+    config.vm.provision "shell", inline: $script
+    config.vm.synced_folder ".", "/opt/reflex-platform", type: 'nfs'
+    config.vm.provider :virtualbox do |vb|
+        vb.customize ["modifyvm", :id, "--usb", "off"]
+        vb.name = "reflex-platform.vagrant"
+        vb.memory = 4096
+        vb.cpus = 2
+    end
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: "2"
+
+services:
+    reflexplatform:
+        build: .
+        command: ./try-reflex


### PR DESCRIPTION
Hey @ryantrinkle, in the past month I've had a bit of trouble getting Reflex working on my machine due to my OS X update to 0.12.2 (16C67). So I've had to use Docker (and optionally Vagrant) to get the `try-reflex` command working. This pull request has a Docker image and Vagrant file to help others in my situate out. 

Please let me know how this looks. And if you need help incorporating Reflex into the Docker ecosystem, I'd love to help.

Brandon