### PR TITLE
change to search for cabal.nix rather than default.nix for work-on

### DIFF
--- a/work-on
+++ b/work-on
@@ -32,12 +32,12 @@ fi
 if echo "$PACKAGE" | grep -q / ; then
     # Package name includes a slash
     PACKAGE_PATH="$(cleanup_nix_path "$PACKAGE")"
-    if ( echo "$PACKAGE_PATH" | grep -q '\.nix$' && [ -f "$PACKAGE_PATH" ] ) || [ -f "$PACKAGE_PATH/default.nix" ] ; then
+    if ( echo "$PACKAGE_PATH" | grep -q '\.nix$' && [ -f "$PACKAGE_PATH" ] ) || [ -f "$PACKAGE_PATH/cabal.nix" ] ; then
         PACKAGE_INVOCATION="($EFFECTIVE_PLATFORM.callPackage $PACKAGE_PATH {})"
     elif test -n "$(shopt -s nullglob ; echo "$PACKAGE_PATH"/*.cabal)" ; then
         PACKAGE_INVOCATION="($EFFECTIVE_PLATFORM.callPackage (this.cabal2nixResult $PACKAGE_PATH) {})"
     else
-        user_error 1 "Error: The given path must be a nix expression, a directory with a default.nix, or a directory with a cabal file"
+        user_error 1 "Error: The given path must be a nix expression, a directory with a cabal.nix, or a directory with a cabal file"
     fi
 else
     PACKAGE_INVOCATION="$EFFECTIVE_PLATFORM.$PACKAGE"


### PR DESCRIPTION
Resolves reflex-frp/reflex-platform#101