### PR TITLE
Added Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ reflex-dom/*
 reflex-todomvc/*
 !reflex-todomvc/default.nix
 !reflex-todomvc/github.json
+.vagrant/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 sudo: required
+services:
+  - docker
+language: generic
 script:
   - git config --global user.email "travis-ci@example.com"
   - git config --global user.name "Travis-CI"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Fork, then clone the repo:
 
-    git clone git@github.com:your-username/reflex.git
+    git clone git@github.com:your-username/try-reflex.git
 
 Make sure the tests pass:
 
@@ -14,4 +14,5 @@ Make your change. Don't forget to add tests and documentation for your change! S
 
 Push to your fork and [submit a pull request][pr].
 
-[pr]: https://github.com/ryantrinkle/reflex/compare/
+[pr]: https://github.com/ryantrinkle/try-reflex/compare/
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM debian:jessie-slim
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 575159689BEFB442
+RUN echo 'deb http://download.fpcomplete.com/debian jessie main' | \
+    tee /etc/apt/sources.list.d/fpco.list
+RUN apt-get update -y && apt-get upgrade -y && apt-get install -y \
+    curl bzip2 build-essential zlib1g zlib1g-dev stack libtinfo-dev libncurses5-dev libncursesw5-dev
+ENV U robot
+RUN useradd -ms /bin/bash $U
+RUN groupadd nixbld && usermod -a -G nixbld $U
+ENV HOME /home/$U
+ENV USER $U
+RUN mkdir -p /nix /opt/reflex-platform && chown -R $U /nix /opt/reflex-platform
+USER $U
+WORKDIR /home/$U
+RUN curl https://nixos.org/nix/install | sh
+RUN . $HOME/.nix-profile/etc/profile.d/nix.sh && \
+    nix-channel --add https://nixos.org/channels/nixpkgs-unstable && \
+    nix-channel --update
+RUN echo ". $HOME/.nix-profile/etc/profile.d/nix.sh" >> ~/.bashrc
+WORKDIR /opt/reflex-platform
+ADD . ./
+USER root
+RUN chown -R $U /opt/reflex-platform
+USER $U
+RUN git config --global user.name "Robot"
+RUN git config --global user.email "robot@brandonstil.es"
+RUN ./try-reflex

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,17 @@
 FROM debian:jessie-slim
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 575159689BEFB442
+ENV LAST_MODIFIED 08-31-2017
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys \
+    575159689BEFB442
 RUN echo 'deb http://download.fpcomplete.com/debian jessie main' | \
     tee /etc/apt/sources.list.d/fpco.list
 RUN apt-get update -y && apt-get upgrade -y && apt-get install -y \
-    curl bzip2 build-essential zlib1g zlib1g-dev stack libtinfo-dev libncurses5-dev libncursesw5-dev
+    software-properties-common python-dev curl bzip2 build-essential zlib1g \
+    zlib1g-dev stack libtinfo-dev libncurses5-dev libncursesw5-dev
 ENV U robot
-RUN useradd -ms /bin/bash $U
-RUN groupadd nixbld && usermod -a -G nixbld $U
+RUN useradd -ms /bin/bash $U && groupadd nixbld && usermod -a -G nixbld $U
 ENV HOME /home/$U
 ENV USER $U
-RUN mkdir -p /nix /opt/reflex-platform && chown -R $U /nix /opt/reflex-platform
+RUN mkdir -p /nix /code/reflex-platform && chown -R $U /nix /code
 USER $U
 WORKDIR /home/$U
 RUN curl https://nixos.org/nix/install | sh
@@ -17,11 +19,10 @@ RUN . $HOME/.nix-profile/etc/profile.d/nix.sh && \
     nix-channel --add https://nixos.org/channels/nixpkgs-unstable && \
     nix-channel --update
 RUN echo ". $HOME/.nix-profile/etc/profile.d/nix.sh" >> ~/.bashrc
-WORKDIR /opt/reflex-platform
-ADD . ./
+ADD . /code/reflex-platform
+WORKDIR /code/reflex-platform
 USER root
-RUN chown -R $U /opt/reflex-platform
+RUN chown -R $U /code/reflex-platform
 USER $U
-RUN git config --global user.name "Robot"
-RUN git config --global user.email "robot@brandonstil.es"
 RUN ./try-reflex
+WORKDIR /code

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+docker:
+	@docker build -t reflex-platform .

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/stilesb/reflex-platform.svg?branch=master)](https://travis-ci.org/stilesb/reflex-platform)
+
 Reflex Platform
 ===============
 
@@ -27,7 +29,7 @@ This process will install the [Nix package manager](https://nixos.org/nix/). If 
     ```
 
 2. Navigate into the `reflex-platform` folder and run the `try-reflex` command. This will install Nix, if you don't have it already, and use it to wrangle all the dependencies you'll need and drop you in an environment from which you can use Reflex. Be warned, this might take a little while the first time:
-    
+
     ```bash
     cd reflex-platform
     ./try-reflex
@@ -235,7 +237,7 @@ numberInput = do
 `numberInput` hasn't changed here. Our `main` function now creates two inputs. `zipDynWith` is used to produce the actual sum of the values of the inputs. The type signature of `zipDynWith` is:
 
 ```haskell
-    Reflex t => (a -> b -> c) -> Dynamic t a -> Dynamic t b -> Dynamic t c 
+    Reflex t => (a -> b -> c) -> Dynamic t a -> Dynamic t b -> Dynamic t c
 ```
 
 You can see that it takes a function that combines two pure values and produces some other pure value, and two `Dynamic`s, and produces a `Dynamic`.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,33 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby:
+
+Vagrant.configure(2) do |config|
+    config.vm.box = "minimal/trusty64"
+    config.vm.hostname = "reflex-platform.vagrant"
+    config.vm.network "private_network", ip: "192.168.50.90"
+    config.vm.provision "shell", inline: <<-SHELL
+        U=vagrant
+        apt-get update -y
+        apt-get install -y apt-transport-https ca-certificates curl
+        apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 \
+            --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+        echo "deb https://apt.dockerproject.org/repo ubuntu-trusty main" | \
+            tee /etc/apt/sources.list.d/docker.list
+        apt-get update -y
+        apt-cache policy docker-engine
+        apt-get install -y docker-engine
+        service docker start
+        gpasswd -a $U docker
+        mkdir -p /home/$U/code
+        exit 0
+    SHELL
+    config.vm.synced_folder ".", "/home/vagrant/code", type: 'nfs'
+    config.vm.provider :virtualbox do |vb|
+        vb.customize ["modifyvm", :id, "--usb", "off"]
+        vb.customize ["modifyvm", :id, "--usbehci", "off"]
+        vb.customize ['modifyvm', :id, '--clipboard', 'bidirectional']
+        vb.name = "reflex-platform.vagrant"
+        vb.memory = 4096
+        vb.cpus = 2
+    end
+end

--- a/reflex-dom/git.nix
+++ b/reflex-dom/git.nix
@@ -1,0 +1,5 @@
+{
+  url = git://github.com/ryantrinkle/reflex-dom.git;
+  rev = "53e1bff1a211e39cc91f9fe6e4f7aa0dc8087583";
+  sha256 = "650454339fca1105f003173a2d2dd3dd850de993f4aa69471a93da6999d8143a";
+}

--- a/reflex/git.nix
+++ b/reflex/git.nix
@@ -1,0 +1,5 @@
+{
+  url = git://github.com/ryantrinkle/reflex;
+  rev = "e7e40d0449b27299e0ff70157ab47115f7ab6b51";
+  sha256 = "9b8aff38c1bfac170c351b69bf80711031f42121bf8c810f33f8bd80f51c18e5";
+}

--- a/test.hs
+++ b/test.hs
@@ -111,3 +111,9 @@ main = hspec $ parallel $ do
       shelly $ silently $ do
         run "nix-shell" []
       return () :: IO ()
+
+  describe "Dockerfile" $ do
+    it "is created successfully" $ do
+      shelly $ silently $ do
+        run "docker" ["build", "."]
+      return () :: IO ()

--- a/try-reflex
+++ b/try-reflex
@@ -64,4 +64,4 @@ EOF
 
 nix-build "$DIR/shell.nix" --drv-link "$DIR/gc-roots/shell.drv" $NIXOPTS --indirect --add-root "$DIR/gc-roots/shell.out" >/dev/null
 terminate_logging
-nix-shell "$DIR/gc-roots/shell.drv" $NIXOPTS --command "echo \"$INFO\" ; return" "$@"
+nix-shell "$DIR/gc-roots/shell.drv" $NIXOPTS --command "echo \"$INFO\";"


### PR DESCRIPTION
Please consider this PR extremely experimental.

It works in the sense that users can create a Docker image based on the repo content. `test.hs` has been updated to include a case for building said image.

This does not work in the sense that users have a robust Docker image for creating Reflex-FRP projects. I'm working on that next.

A couple comments though:

1. Not sure how this change affects the repo?

```
 -nix-shell "$DIR/gc-roots/shell.drv" $NIXOPTS --command "echo \"$INFO\" ; return" "$@"
+nix-shell "$DIR/gc-roots/shell.drv" $NIXOPTS --command "echo \"$INFO\";"
```

Edit: Fixed `.travis.yml` build