### PR TITLE
Use nixpkgs' lib.composeExtensions in combineOverrides

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -216,9 +216,7 @@ let overrideCabal = pkg: f: if pkg == null then null else lib.overrideCabal pkg 
       editedCabalFile = null;
     });
     combineOverrides = old: new: (old // new) // {
-      overrides = self: super:
-        let oldOverrides = old.overrides self super;
-        in oldOverrides // new.overrides self (super // oldOverrides);
+      overrides = nixpkgs.lib.composeExtensions old.overrides new.overrides;
     };
     makeRecursivelyOverridable = x: old: x.override old // {
       override = new: makeRecursivelyOverridable x (combineOverrides old new);


### PR DESCRIPTION
One small step in upstreaming this useful function. Note the argument order for the upstream function is non-standard for function composition, but does match `//` I suppose.

I think plain `lib` is the haskell library, so I used `nixpkgs.lib`. But I only see that in other other spot, so not sure whether it is the best way. 