### PR TITLE
GHC 7.10 fixes

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -438,6 +438,12 @@ let overrideCabal = pkg: f: if pkg == null then null else lib.overrideCabal pkg 
     overrideForGhc7 = haskellPackages: haskellPackages.override {
       overrides = self: super: {
         cereal = dontCheck super.cereal; # cereal's test suite requires a newer version of bytestring than this haskell environment provides
+        ghcjs-dom = overrideCabal super.ghcjs-dom (drv: {
+          preConfigure = "sed -i -e 's|cabal-version: >=1.24|cabal-version: >=1.22|' ghcjs-dom.cabal";
+        });
+        ghcjs-dom-ffi = overrideCabal super.ghcjs-dom-ffi (drv: {
+          preConfigure = "sed -i -e 's|cabal-version: >=1.24|cabal-version: >=1.22|' ghcjs-dom-ffi.cabal";
+        });
       };
     };
     overrideForGhc7_8 = haskellPackages: (overrideForGhc7 haskellPackages).override {

--- a/default.nix
+++ b/default.nix
@@ -438,9 +438,11 @@ let overrideCabal = pkg: f: if pkg == null then null else lib.overrideCabal pkg 
     overrideForGhc7 = haskellPackages: haskellPackages.override {
       overrides = self: super: {
         cereal = dontCheck super.cereal; # cereal's test suite requires a newer version of bytestring than this haskell environment provides
+        # Manually patch minimum cabal allowed to accept the version included with ghc 7.10
         ghcjs-dom = overrideCabal super.ghcjs-dom (drv: {
           preConfigure = "sed -i -e 's|cabal-version: >=1.24|cabal-version: >=1.22|' ghcjs-dom.cabal";
         });
+        # Manually patch minimum cabal allowed to accept the version included with ghc 7.10
         ghcjs-dom-ffi = overrideCabal super.ghcjs-dom-ffi (drv: {
           preConfigure = "sed -i -e 's|cabal-version: >=1.24|cabal-version: >=1.22|' ghcjs-dom-ffi.cabal";
         });

--- a/jsaddle/github.json
+++ b/jsaddle/github.json
@@ -1,6 +1,6 @@
 {
-  "owner": "ghcjs",
+  "owner": "luigy",
   "repo": "jsaddle",
-  "rev": "85c8fb14542012667ce4bb202ca63903b2656043",
-  "sha256": "1qspan2fxw20yx1b5nm5p68m3y13rknkcy69s3rz46aylxrrykcp"
+  "rev": "e608075d3682b3e8d170f88423ae6b53beac6e38",
+  "sha256": "1920sp5j63kdhcgnvkkrv8hfx17r0fia8y4rpgm2xyzjcywkxjgi"
 }


### PR DESCRIPTION
* Fixes `ghcjs-dom` to build with 7.10
* Fixes `jsaddle` to build with 7.10