### PR TITLE
add patch to make say compile with JSString text

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -687,6 +687,14 @@ let overrideCabal = pkg: f: if pkg == null then null else lib.overrideCabal pkg 
           sha256 = "0sjljf1sbwalw1zycpjf6bqhljag9i1k77b18b0fd1pzrc29wnks";
         };
       });
+      say = overrideCabal super.say (drv: {
+        patches = (drv.patches or []) ++ [
+          ./say-text-jsstring.patch
+        ];
+        buildDepends = (drv.buildDepends or []) ++ [
+          self.ghcjs-base
+        ];
+      });
     };
   ghcHEAD = overrideForGhcHEAD (overrideForGhc8 (overrideForGhc (extendHaskellPackages nixpkgs.pkgs.haskell.packages.ghcHEAD)));
   ghc = overrideForGhc8 (overrideForGhc (extendHaskellPackages nixpkgs.pkgs.haskell.packages.ghc802));

--- a/say-text-jsstring.patch
+++ b/say-text-jsstring.patch
@@ -1,0 +1,22 @@
+diff --git a/src/Say.hs b/src/Say.hs
+index a1f6802..fd9145d 100644
+--- a/src/Say.hs
++++ b/src/Say.hs
+@@ -146,7 +146,7 @@ hSay h msg =
+                 return new_buf
+ 
+     writeBlocksRaw :: Buffer CharBufElem -> Stream Char -> IO ()
+-    writeBlocksRaw buf0 (Stream next0 s0 _len) =
++    writeBlocksRaw buf0 (Stream next0 s0) =
+         outer s0 buf0
+       where
+         outer s1 Buffer{bufRaw=raw, bufSize=len} =
+@@ -168,7 +168,7 @@ hSay h msg =
+                 flush = commit n True{-needs flush-} False{-don't release-} >>= outer s
+ 
+     writeBlocksCRLF :: Buffer CharBufElem -> Stream Char -> IO ()
+-    writeBlocksCRLF buf0 (Stream next0 s0 _len) =
++    writeBlocksCRLF buf0 (Stream next0 s0) =
+         outer s0 buf0
+       where
+         outer s1 Buffer{bufRaw=raw, bufSize=len} =


### PR DESCRIPTION
pretty straightforward - say uses internals of Text which change when using the JSString text patch, so it has to change a little