### PR TITLE
Updated jsaddle, ghcjs-dom and jsaddle-dom to current master.

### DIFF
--- a/ghcjs-dom/github.json
+++ b/ghcjs-dom/github.json
@@ -1,6 +1,6 @@
 {
   "owner": "ghcjs",
   "repo": "ghcjs-dom",
-  "rev": "b5984c8326f6eb1e29f2ca60c0e88eb6ecfdc0c1",
-  "sha256": "1dspap1cgjz8fy98bxb18mxyi2gwscrcnzbfblki2jg11c4drll7"
+  "rev": "9f5836ecdde832e575c9fdcb501598f6d3e3d7e1",
+  "sha256": "1qx5sbbgclyggp11k5kbndhyq7mf7wcrr2jyq2cwg7xfajyfgvnr"
 }

--- a/jsaddle-dom/github.json
+++ b/jsaddle-dom/github.json
@@ -1,6 +1,6 @@
 {
   "owner": "ghcjs",
   "repo": "jsaddle-dom",
-  "rev": "0c3f8c60a15fba49bea8d9e4fa871fb1e40460d4",
-  "sha256": "0kyr9vpgly8m919dij9pxsaz01ln1gqgicnja191yg0wi80fi5l6"
+  "rev": "a565feac5df24d26e6fec5463bcb70e3e2fd683b",
+  "sha256": "0na40w2zc6v3vr60vjpjl8v9nm39ias7kxxs4ci6mk1p0ylv45rp"
 }

--- a/jsaddle/github.json
+++ b/jsaddle/github.json
@@ -1,6 +1,6 @@
 {
-  "owner": "obsidiansystems",
+  "owner": "ghcjs",
   "repo": "jsaddle",
-  "rev": "24bc75e93e93f21547e2159ef3d6d39804d7f0e9",
-  "sha256": "1rhyh2w3d9xrqwj4x7k8a978aclfy0in6amz494rwwqf2qxknlpw"
+  "rev": "b0de8bf2dcc4b9171bcddb64a847768aec5eee39",
+  "sha256": "1f780cwl081yzd6gfblz0krr6pmnjkybngw9448nw294vinsb20n"
 }


### PR DESCRIPTION
Those updates contain some bugfixes, especially in ghcjs-dom-jsffi: Here the reject case of promises is now handled correctly.