### PR TITLE
Android dead code elimination

### DIFF
--- a/android/haskellActivity.version
+++ b/android/haskellActivity.version
@@ -1,0 +1,4 @@
+ONE {
+    global: JNI_OnLoad; Java*;
+    local: *;
+};

--- a/android/impl.nix
+++ b/android/impl.nix
@@ -1,7 +1,7 @@
 env: with env;
 let overrideAndroidCabal = package: overrideCabal package (drv: {
       preConfigure = (drv.preConfigure or "") + ''
-        sed -i 's/^executable \(.*\)$/executable lib\1.so\n  cc-options: -shared -fPIC\n  ld-options: -shared -Wl,-u,Java_systems_obsidian_HaskellActivity_haskellStartMain,-u,hs_main\n  ghc-options: -shared -fPIC -threaded -no-hs-main -lHSrts_thr -lCffi -lm -llog/i' *.cabal
+        sed -i 's%^executable \(.*\)$%executable lib\1.so\n  cc-options: -shared -fPIC\n  ld-options: -shared -Wl,--gc-sections,--version-script=${./haskellActivity.version},-u,Java_systems_obsidian_HaskellActivity_haskellStartMain,-u,hs_main\n  ghc-options: -shared -fPIC -threaded -no-hs-main -lHSrts_thr -lCffi -lm -llog%i' *.cabal
       '';
     });
     addDeployScript = src: nixpkgs.runCommand "android-app" {


### PR DESCRIPTION
Ok, so there are two main things going on here.  First is turning on `--gc-sections` in the linker, to get it to do dead code elimination once we've told it what our entry points are, and the other is giving it those entry points.  The latter is done with a linker version script, which is really straightforward.  It basically says "keep all the symbols that are either `JNI_OnLoad` or start with `Java` (that is, all the symbols in the various C bits that are marked with `JNIEXPORT`) and hide all the other things.  The result of this for my MagiCounter app is a 5MB APK file which unzips to about 15MB of storage on installation.

The version-script interpolation is _really quite hacky_ as it'll break if the resolved path contains any `%` characters or other things that will affect the replacement-side of a sed script.