### PR TITLE
Android: Build separate APKs per-abi

### DIFF
--- a/android/build.gradle.nix
+++ b/android/build.gradle.nix
@@ -72,6 +72,32 @@ android {
 
     packagingOptions {
     }
+
+    // see https://developer.android.com/studio/build/configure-apk-splits.html
+    // for information about this and the applicationVariants stuff below
+    splits {
+        abi {
+            enable true
+            reset()
+            include "armeabi-v7a", "arm64-v8a"
+            universalApk false
+        }
+    }
+}
+
+ext.abiCodes = ['armeabi-v7a': 1, 'arm64-v8a': 2] // This order is important!
+
+import com.android.build.OutputFile
+
+android.applicationVariants.all { variant ->
+  variant.outputs.each { output ->
+    def baseAbiVersionCode =
+      project.ext.abiCodes.get(output.getFilter(OutputFile.ABI))
+
+    if (baseAbiVersionCode != null) {
+      output.versionCodeOverride = baseAbiVersionCode * 1000 + variant.versionCode
+    }
+  }
 }
 
 dependencies {

--- a/android/build.gradle.nix
+++ b/android/build.gradle.nix
@@ -4,6 +4,7 @@
 , additionalDependencies
 , googleServicesClasspath
 , googleServicesPlugin
+, universalApk
 }:
 ''
 buildscript {
@@ -74,14 +75,19 @@ android {
     }
 
     // see https://developer.android.com/studio/build/configure-apk-splits.html
-    // for information about this and the applicationVariants stuff below
-    splits {
-        abi {
-            enable true
-            reset()
-            include "armeabi-v7a", "arm64-v8a"
-            universalApk false
+    // for information about this and the applicationVariants stuff below.
+    // See https://developer.android.com/google/play/publishing/multiple-apks.html#SingleAPK
+    // for reasons you might not want to do this.
+    ${if universalApk then "" else ''
+        splits {
+            abi {
+                enable true
+                reset()
+                include "armeabi-v7a", "arm64-v8a"
+                universalApk false
+            }
         }
+        ''
     }
 }
 
@@ -94,7 +100,7 @@ android.applicationVariants.all { variant ->
     def baseAbiVersionCode =
       project.ext.abiCodes.get(output.getFilter(OutputFile.ABI))
 
-    if (baseAbiVersionCode != null) {
+    if (baseAbiVersionCode != null) { // this will be null if splitting was disabled
       output.versionCodeOverride = baseAbiVersionCode * 1000 + variant.versionCode
     }
   }

--- a/android/default.nix
+++ b/android/default.nix
@@ -89,6 +89,11 @@ in rec {
     , googleServicesJson ? null
 
     , additionalDependencies ? ""
+
+    , universalApk ? true
+      # Set this to false to build one APK per target platform.  This will
+      # automatically transform the version code to 1000 * versionCode + offset
+      # where "offset" is a per-platform constant.
     }: impl.buildApp {
       inherit package
               executableName
@@ -103,6 +108,7 @@ in rec {
               services
               intentFilters
               googleServicesJson
-              additionalDependencies;
+              additionalDependencies
+              universalApk;
     };
 }

--- a/android/impl.nix
+++ b/android/impl.nix
@@ -54,7 +54,7 @@ in {
           abiVersions = attrNames appSOs;
       in nixpkgs.runCommand "android-app" {
         buildGradle = builtins.toFile "build.gradle" (import ./build.gradle.nix {
-          inherit applicationId version additionalDependencies releaseKey;
+          inherit applicationId version additionalDependencies releaseKey universalApk;
           googleServicesClasspath = optionalString (googleServicesJson != null)
             "classpath 'com.google.gms:google-services:3.0.0'";
           googleServicesPlugin = optionalString (googleServicesJson != null)


### PR DESCRIPTION
Because the libraries generated, even after dead code elimination, are quite large, configures the gradle script to build a separate APK for each supported target platform.

I'd like to make this optional before merging it, as there are a few drawbacks to doing things this way.  That looks pretty straightforward, though.

