### PR TITLE
Bump nixpkgs for fixed Haskell dev shells

### DIFF
--- a/nixpkgs/github.json
+++ b/nixpkgs/github.json
@@ -1,6 +1,6 @@
 {
   "owner": "obsidiansystems",
   "repo": "nixpkgs",
-  "rev": "39d2676ab9f83f1173d5ce0ff1aaef902474e45d",
-  "sha256": "05md1j65v7a0xxzggf5ixmk7z57j3xl5na9y225944fm5czmigim"
+  "rev": "5304be5754c84c7eadf1149d781c711feca6671f",
+  "sha256": "1sfw32di8cwp3xg2hqildqn7hv4nqz4906g0jrdk3slja1mj90iy"
 }


### PR DESCRIPTION
Not sure if the problem at hand is actually fixed (due to time constraints), but stuff at least builds, so might as well kick off a `./test`. @luigy let's test this soon.