### PR TITLE
Fix impl.nix cabal file 'sed'

### DIFF
--- a/android/impl.nix
+++ b/android/impl.nix
@@ -1,7 +1,7 @@
 env: with env;
 let overrideAndroidCabal = package: overrideCabal package (drv: {
       preConfigure = (drv.preConfigure or "") + ''
-        sed -i 's%^executable \(.*\)$%executable lib\1.so\n  cc-options: -shared -fPIC\n  ld-options: -shared -Wl,--gc-sections,--version-script=${./haskellActivity.version},-u,Java_systems_obsidian_HaskellActivity_haskellStartMain,-u,hs_main\n  ghc-options: -shared -fPIC -threaded -no-hs-main -lHSrts_thr -lCffi -lm -llog%i' *.cabal
+        sed -i 's%^executable *\(.*\)$%executable lib\1.so\n  cc-options: -shared -fPIC\n  ld-options: -shared -Wl,--gc-sections,--version-script=${./haskellActivity.version},-u,Java_systems_obsidian_HaskellActivity_haskellStartMain,-u,hs_main\n  ghc-options: -shared -fPIC -threaded -no-hs-main -lHSrts_thr -lCffi -lm -llog%i' *.cabal
       '';
     });
     addDeployScript = src: nixpkgs.runCommand "android-app" {

--- a/android/impl.nix
+++ b/android/impl.nix
@@ -1,7 +1,7 @@
 env: with env;
 let overrideAndroidCabal = package: overrideCabal package (drv: {
       preConfigure = (drv.preConfigure or "") + ''
-        sed -i 's%^executable +\(.*\)$%executable lib\1.so\n  cc-options: -shared -fPIC\n  ld-options: -shared -Wl,--gc-sections,--version-script=${./haskellActivity.version},-u,Java_systems_obsidian_HaskellActivity_haskellStartMain,-u,hs_main\n  ghc-options: -shared -fPIC -threaded -no-hs-main -lHSrts_thr -lCffi -lm -llog%i' *.cabal
+        sed -i 's%^executable *\(.*\)$%executable lib\1.so\n  cc-options: -shared -fPIC\n  ld-options: -shared -Wl,--gc-sections,--version-script=${./haskellActivity.version},-u,Java_systems_obsidian_HaskellActivity_haskellStartMain,-u,hs_main\n  ghc-options: -shared -fPIC -threaded -no-hs-main -lHSrts_thr -lCffi -lm -llog%i' *.cabal
       '';
     });
     addDeployScript = src: nixpkgs.runCommand "android-app" {

--- a/android/impl.nix
+++ b/android/impl.nix
@@ -1,7 +1,7 @@
 env: with env;
 let overrideAndroidCabal = package: overrideCabal package (drv: {
       preConfigure = (drv.preConfigure or "") + ''
-        sed -i 's%^executable *\(.*\)$%executable lib\1.so\n  cc-options: -shared -fPIC\n  ld-options: -shared -Wl,--gc-sections,--version-script=${./haskellActivity.version},-u,Java_systems_obsidian_HaskellActivity_haskellStartMain,-u,hs_main\n  ghc-options: -shared -fPIC -threaded -no-hs-main -lHSrts_thr -lCffi -lm -llog%i' *.cabal
+        sed -i 's%^executable +\(.*\)$%executable lib\1.so\n  cc-options: -shared -fPIC\n  ld-options: -shared -Wl,--gc-sections,--version-script=${./haskellActivity.version},-u,Java_systems_obsidian_HaskellActivity_haskellStartMain,-u,hs_main\n  ghc-options: -shared -fPIC -threaded -no-hs-main -lHSrts_thr -lCffi -lm -llog%i' *.cabal
       '';
     });
     addDeployScript = src: nixpkgs.runCommand "android-app" {


### PR DESCRIPTION
Currently when building for android it will fail with a parse error on the executable name when reading the cabal file. This is because in the 'impl.nix' file it adjusts the cabal file with 'sed', and only allows for one space immediately following the word "executable".

So if you have:
executable        foo
You will end up with:
executable lib        foo.so
Not:
executable libfoo.so

Adding a '+' for the whitespace means it will try to match on one or more whitespace. 