### PR TITLE
Reflex Project: fix overrides

### DIFF
--- a/project/default.nix
+++ b/project/default.nix
@@ -112,8 +112,8 @@ in
 
 }:
 let
-  overrides' = nixpkgs.lib.composeExtensions overrides
-    (self: super: mapAttrs (name: path: self.callCabal2nix name path {}) packages);
+  overrides' = nixpkgs.lib.composeExtensions
+    (self: super: mapAttrs (name: path: self.callCabal2nix name path {}) packages) overrides;
   mkPkgSet = name: _: this.${name}.override { overrides = overrides'; };
 in makeExtensible (prj: mapAttrs mkPkgSet shells // {
   shells = mapAttrs (name: pnames:


### PR DESCRIPTION
`composeExtensions` was called with wrong order of arguments.

Rational: `composeExtensions` documentations says that changes in the
first argument are available in the `super` of the second.

In the previous version, changes (thanks to overrides) are available in
the super of the block containing "callCabal2nix", which does not use
super, so overrides was not used.

In this version, changes in the first argument (i.e.: the different call
to "callCabal2nix") are finally available in the "super" of the
override.

(Discussed on IRC with elvishjerricco, who understood the issue and
proposed the fix)