### PR TITLE
Require explicit consent when running High Sierra prior to 10.13.2

### DIFF
--- a/common-setup.sh
+++ b/common-setup.sh
@@ -130,7 +130,19 @@ EOF
     fi
 }
 
-
+osx_freeze_version="10.13.1"
+allow_broken_macos="$HOME/.local/share/reflex-platform/allow-broken-macos"
+if (sw_vers | grep "ProductVersion" | grep "$osx_freeze_version" || false)  &> /dev/null; then
+    if [ ! -d "$allow_broken_macos" ]; then
+	echo ""
+	echo "Running nix on High Sierra $osx_freeze_version can cause system crashes"
+	echo "See https://github.com/NixOS/nix/issues/1583"
+	echo "Please update your system to continue safely"
+	echo "If you still want to try, do:"
+	echo "mkdir -p $allow_broken_macos"
+	exit 1
+    fi;
+fi
 
 >&2 echo "If you have any trouble with this script, please submit an issue at $REPO/issues"
 

--- a/common-setup.sh
+++ b/common-setup.sh
@@ -133,8 +133,7 @@ EOF
 allow_broken_macos="$HOME/.local/share/reflex-platform/allow-broken-macos"
 if (sw_vers | grep "ProductVersion" | grep "\(10.13.0\|10.13.2\)$" || false)  &> /dev/null; then
     if [ ! -d "$allow_broken_macos" ]; then
-	echo ""
-	echo "Running nix on High Sierra versions prior to 10.13.2 can cause system crashes"
+	echo "Running nix on High Sierra versions prior to 10.13.2 is likely to cause system crashes"
 	echo "See https://github.com/NixOS/nix/issues/1583"
 	echo "Please update your system to continue safely"
 	echo "If you still want to try, do:"

--- a/common-setup.sh
+++ b/common-setup.sh
@@ -130,12 +130,11 @@ EOF
     fi
 }
 
-osx_freeze_version="10.13.1"
 allow_broken_macos="$HOME/.local/share/reflex-platform/allow-broken-macos"
-if (sw_vers | grep "ProductVersion" | grep "$osx_freeze_version$" || false)  &> /dev/null; then
+if (sw_vers | grep "ProductVersion" | grep "\(10.13.0\|10.13.2\)$" || false)  &> /dev/null; then
     if [ ! -d "$allow_broken_macos" ]; then
 	echo ""
-	echo "Running nix on High Sierra $osx_freeze_version can cause system crashes"
+	echo "Running nix on High Sierra versions prior to 10.13.2 can cause system crashes"
 	echo "See https://github.com/NixOS/nix/issues/1583"
 	echo "Please update your system to continue safely"
 	echo "If you still want to try, do:"

--- a/common-setup.sh
+++ b/common-setup.sh
@@ -132,7 +132,7 @@ EOF
 
 osx_freeze_version="10.13.1"
 allow_broken_macos="$HOME/.local/share/reflex-platform/allow-broken-macos"
-if (sw_vers | grep "ProductVersion" | grep "$osx_freeze_version" || false)  &> /dev/null; then
+if (sw_vers | grep "ProductVersion" | grep "$osx_freeze_version$" || false)  &> /dev/null; then
     if [ ! -d "$allow_broken_macos" ]; then
 	echo ""
 	echo "Running nix on High Sierra $osx_freeze_version can cause system crashes"


### PR DESCRIPTION
Fix #196 in the sense that users are warned about the dangers and pointed to the root problem.
Don't really see anything else we can do here.
  