### PR TITLE
Retain the default binary cache on NixOS

### DIFF
--- a/notes/NixOS.md
+++ b/notes/NixOS.md
@@ -3,7 +3,7 @@
 When using Nix on NixOS, only root can add binary caches to the system.  This will force `try-reflex` to rebuild GHCJS from scratch, which takes hours.  To use the binary cache, you can add the following lines to your `/etc/nixos/configuration.nix`:
 
 ```
-nix.binaryCaches = [ "https://nixcache.reflex-frp.org" ];
+nix.binaryCaches = [ "https://cache.nixos.org/" "https://nixcache.reflex-frp.org" ];
 nix.binaryCachePublicKeys = [ "ryantrinkle.com-1:JJiAKaRv9mWgpVAz8dwewnZe0AzzEAzPkagE9SP5NWI=" ];
 ```
 


### PR DESCRIPTION
The default value (`"https://cache.nixos.org/"`) gets overridden if we customize this value in configuration.nix. This leads to unnecessarily compiling large packages (`nix-shell -p gcc822` for example would compile GCC 8.2.2 instead of using Nix's binary cache).