### PR TITLE
Disables the tests for 'linear' and 'bytes' for ghcjs

### DIFF
--- a/haskell-overlays/ghcjs.nix
+++ b/haskell-overlays/ghcjs.nix
@@ -20,5 +20,7 @@ self: super: {
   };
 
   diagrams-lib = haskellLib.dontCheck super.diagrams-lib;
+  linear = haskellLib.dontCheck (self.callHackage "linear" "1.20.7" {});
+  bytes = haskellLib.dontCheck (self.callHackage "bytes" "0.15.3" {});
 
 }


### PR DESCRIPTION
The default packages rely on 'doctest', which isn't compiling. Specifying another version of 'doctest' also isn't
working; at least for doctest-0.13.0.