### PR TITLE
Use consistent indentation in common-setup.sh

### DIFF
--- a/common-setup.sh
+++ b/common-setup.sh
@@ -7,11 +7,11 @@ NIXOPTS="--option extra-binary-caches https://nixcache.reflex-frp.org"
 
 NIX_CONF="/etc/nix/nix.conf"
 
-if [ -e "$NIX_CONF" ] && grep -q 'https://ryantrinkle\.com:5443' "$NIX_CONF" ; then
-    >&2 echo "Warning: The reflex-platform cache server has moved from https://ryantrinkle.com:5443 to https://nixcache.reflex-frp.org.  Please update your /etc/nixos/configuration/nix or /etc/nix/nix.conf accordingly"
-    if ! grep -q 'https://nixcache\.reflex-frp\.org' ; then
-        NIXOPTS+=" --option extra-binary-caches https://ryantrinkle.com:5443"
-    fi
+if [ -e "$NIX_CONF" ] && grep -q 'https://ryantrinkle\.com:5443' "$NIX_CONF"; then
+  >&2 echo "Warning: The reflex-platform cache server has moved from https://ryantrinkle.com:5443 to https://nixcache.reflex-frp.org.  Please update your /etc/nixos/configuration/nix or /etc/nix/nix.conf accordingly"
+  if ! grep -q 'https://nixcache\.reflex-frp\.org' ; then
+    NIXOPTS+=" --option extra-binary-caches https://ryantrinkle.com:5443"
+  fi
 fi
 
 LOGFILE="$0.log"
@@ -33,18 +33,18 @@ exec 4>&-
 
 # Exit because the user caused an error, with the given error code and message
 user_error() {
-    >&2 echo "$2"
-    trap - ERR
-    exit "$1"
+  >&2 echo "$2"
+  trap - ERR
+  exit "$1"
 }
 
 on_darwin_host() { [ "$(uname -s)" == 'Darwin' ]; }
 
 reset_daemon() {
-    if on_darwin_host; then
-        sudo launchctl stop org.nixos.nix-daemon
-        sudo launchctl start org.nixos.nix-daemon
-    fi;
+  if on_darwin_host; then
+    sudo launchctl stop org.nixos.nix-daemon
+    sudo launchctl start org.nixos.nix-daemon
+  fi
 }
 
 installing_nix=false
@@ -56,96 +56,97 @@ our_cache="https://nixcache.reflex-frp.org"
 our_key="JJiAKaRv9mWgpVAz8dwewnZe0AzzEAzPkagE9SP5NWI="
 
 nixconf_exists() {
-    if [ -e "$nixconf" ]; then return 0; else return 1; fi;
+  if [ -e "$nixconf" ]; then return 0; else return 1; fi;
 }
 
 nixconf_has_cache_settings() {
-    if nixconf_exists && grep -q '^binary-caches\|^binary-cache-public-keys\|^binary-caches-parallel-connections' "$nixconf" ; then return 0; else return 1; fi;
+  if nixconf_exists && grep -q '^binary-caches\|^binary-cache-public-keys\|^binary-caches-parallel-connections' "$nixconf" ; then return 0; else return 1; fi;
 }
 
 nixconf_has_reflex_cache() {
-    if nixconf_has_cache_settings && grep -q "$our_cache" "$nixconf"; then return 0; else return 1; fi;
+  if nixconf_has_cache_settings && grep -q "$our_cache" "$nixconf"; then return 0; else return 1; fi;
 }
 
 nixconf_has_reflex_key() {
-    if nixconf_has_cache_settings && grep -q "$our_key" "$nixconf"; then return 0; else return 1; fi;
+  if nixconf_has_cache_settings && grep -q "$our_key" "$nixconf"; then return 0; else return 1; fi;
 }
 
 enable_cache() {
-    if [ -e "$skip_cache_setup" ]; then return 0; fi;
+  if [ -e "$skip_cache_setup" ]; then return 0; fi;
 
-    if nixconf_has_reflex_cache && nixconf_has_reflex_key; then return 0; fi;
+  if nixconf_has_reflex_cache && nixconf_has_reflex_key; then return 0; fi;
 
-    if uname -v | grep -i "\bnixos\b"; then
-	echo "Please enable reflex's binary cache by following the instructions at https://github.com/reflex-frp/reflex-platform/blob/develop/notes/NixOS.md"
-	return 0;
-    fi;
+  if uname -v | grep -i "\bnixos\b"; then
+    echo "Please enable reflex's binary cache by following the instructions at https://github.com/reflex-frp/reflex-platform/blob/develop/notes/NixOS.md"
+    return 0;
+  fi
 
-    $(mkdir -p "$user_prefs")
-    if [ "$installing_nix" = false ]; then
-	read -p "Add binary caches for reflex to $nixconf ?"
-	select yn in "Yes" "No" "Ask again next time"; do
-	    case $yn in
-		"Yes" )
-		    break;;
-		"No" )
-		    touch $skip_cache_setup
-		    echo "To re-enable this prompt do: "
-		    echo "rm $skip_cache_setup"
-		    echo ""
-		    return 0;;
-		"Ask again next time" )
-		    return 0;;
-	    esac
-	done
-    fi;
+  mkdir -p "$user_prefs"
+  if [ "$installing_nix" = false ]; then
+    read -rp "Add binary caches for reflex to $nixconf ?"
+    select yn in "Yes" "No" "Ask again next time"; do
+      case $yn in
+        "Yes" )
+          break;;
+        "No" )
+          touch "$skip_cache_setup"
+          echo "To re-enable this prompt do: "
+          echo "rm $skip_cache_setup"
+          echo ""
+          return 0;;
+        "Ask again next time" )
+          return 0;;
+      esac
+    done
+  fi
 
-    sudo_msg="This requires root access."
-    backup="$nixconf.$(date -u +"%FT%TZ").bak"
-    if nixconf_exists; then
-	echo "$nixconf already exists: creating backup - $sudo_msg"
-	sudo cp "$nixconf" "$backup"
-	echo "backup saved at $backup"
-    fi;
+  sudo_msg="This requires root access."
+  backup="$nixconf.$(date -u +"%FT%TZ").bak"
+  if nixconf_exists; then
+    echo "$nixconf already exists: creating backup - $sudo_msg"
+    sudo cp "$nixconf" "$backup"
+    echo "backup saved at $backup"
+  fi
 
-    caches_line="binary-caches = https://cache.nixos.org $our_cache"
-    keys_line="binary-cache-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= ryantrinkle.com-1:$our_key"
-    if ! nixconf_has_cache_settings; then
-	if ! nixconf_exists;
-	then echo "Creating $nixconf - $sudo_msg";
-	else echo "Adding cache settings to $nixconf - $sudo_msg";
-	fi;
-	sudo mkdir -p "$nixconf_dir"
-	sudo tee -a "$nixconf" > /dev/null <<EOF
+  caches_line="binary-caches = https://cache.nixos.org $our_cache"
+  keys_line="binary-cache-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= ryantrinkle.com-1:$our_key"
+  if ! nixconf_has_cache_settings; then
+    if ! nixconf_exists; then
+      echo "Creating $nixconf - $sudo_msg";
+    else
+      echo "Adding cache settings to $nixconf - $sudo_msg";
+    fi
+    sudo mkdir -p "$nixconf_dir"
+    sudo tee -a "$nixconf" > /dev/null <<EOF
 $caches_line
 $keys_line
 binary-caches-parallel-connections = 40
 EOF
-	reset_daemon
-    else
-	echo "Adding cache settings to $nixconf - $sudo_msg"
-	if ! nixconf_has_reflex_cache; then
-            sudo sed -i.bak 's|^\(binary-caches[ =].*\)$|\1 '"$our_cache"'|' "$nixconf"
-	fi
-	if ! nixconf_has_reflex_key; then
-            sudo sed -i.bak 's|^\(binary-cache-public-keys[ =].*\)$|\1 ryantrinkle.com-1:'"$our_key"'|' "$nixconf"
-	fi
-	reset_daemon
+    reset_daemon
+  else
+    echo "Adding cache settings to $nixconf - $sudo_msg"
+    if ! nixconf_has_reflex_cache; then
+      sudo sed -i.bak 's|^\(binary-caches[ =].*\)$|\1 '"$our_cache"'|' "$nixconf"
     fi
+    if ! nixconf_has_reflex_key; then
+      sudo sed -i.bak 's|^\(binary-cache-public-keys[ =].*\)$|\1 ryantrinkle.com-1:'"$our_key"'|' "$nixconf"
+    fi
+    reset_daemon
+  fi
 }
 
 if on_darwin_host; then
-    if (sw_vers | grep "ProductVersion" | grep "\(10.13.0\|10.13.1\)$" || false) &> /dev/null; then
-        allow_broken_macos="$HOME/.local/share/reflex-platform/allow-broken-macos"
-        if [ ! -d "$allow_broken_macos" ]; then
-            echo "Running nix on High Sierra versions prior to 10.13.2 is likely to cause system crashes"
-            echo "See https://github.com/NixOS/nix/issues/1583"
-            echo "Please update your system to continue safely"
-            echo "If you still want to try, do:"
-            echo "mkdir -p $allow_broken_macos"
-            exit 1
-        fi;
-    fi;
+  if (sw_vers | grep "ProductVersion" | grep "\(10.13.0\|10.13.1\)$" || false) &> /dev/null; then
+    allow_broken_macos="$HOME/.local/share/reflex-platform/allow-broken-macos"
+    if [ ! -d "$allow_broken_macos" ]; then
+      echo "Running nix on High Sierra versions prior to 10.13.2 is likely to cause system crashes"
+      echo "See https://github.com/NixOS/nix/issues/1583"
+      echo "Please update your system to continue safely"
+      echo "If you still want to try, do:"
+      echo "mkdir -p $allow_broken_macos"
+      exit 1
+    fi
+  fi
 fi
 
 >&2 echo "If you have any trouble with this script, please submit an issue at $REPO/issues"
@@ -154,7 +155,7 @@ fi
 
 cd "$DIR"
 
-if [ ! -d /nix ] ; then
+if [ ! -d /nix ]; then
   installing_nix=true
   if ! type -P curl >/dev/null ; then
     echo "Please make sure that 'curl' is installed and can be run from this shell"
@@ -168,21 +169,21 @@ fi
 )
 
 # The command to source the nix script.  This should be a line of valid bash code.
-if [ -O /nix/store ] ; then
-    SOURCE_NIX_SCRIPT=". $HOME/.nix-profile/etc/profile.d/nix.sh"
+if [ -O /nix/store ]; then
+  SOURCE_NIX_SCRIPT=". $HOME/.nix-profile/etc/profile.d/nix.sh"
 else
-    SOURCE_NIX_SCRIPT=". /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh"
+  SOURCE_NIX_SCRIPT=". /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh"
 fi
 
 # Whether the nix script needed to be sourced - i.e. nix commands are not available without doing so, from the user's basic prompt.
 NEEDED_TO_SOURCE_NIX_SCRIPT=0
 
-if ! type -P nix-shell >/dev/null ; then
+if ! type -P nix-shell >/dev/null; then
   set +eu
   $SOURCE_NIX_SCRIPT
   set -eu
   NEEDED_TO_SOURCE_NIX_SCRIPT=1
-  if ! type -P nix-shell >/dev/null ; then
+  if ! type -P nix-shell >/dev/null; then
     echo "It looks like Nix isn't working.  Please make sure you can run nix-shell, then retry the $0, or submit an issue at $REPO/issues"
     exit 1
   fi
@@ -191,9 +192,9 @@ fi
 # The minimum required version of Nix to run this script.
 MIN_REQUIRED_NIX_VERSION="1.8"
 
-if [ "$(nix-instantiate --eval --expr "builtins.compareVersions builtins.nixVersion \"$MIN_REQUIRED_NIX_VERSION\" >= 0")" != "true" ] ; then
+if [ "$(nix-instantiate --eval --expr "builtins.compareVersions builtins.nixVersion \"$MIN_REQUIRED_NIX_VERSION\" >= 0")" != "true" ]; then
   echo "It looks like your version of Nix, $(nix-instantiate --eval --expr "builtins.nixVersion"), is older than the minimum version required by the Reflex Platform, \"$MIN_REQUIRED_NIX_VERSION\".  You'll need to upgrade Nix to continue.  On non-NixOS platforms, that can usually be done like this:"
-  if [ "$NEEDED_TO_SOURCE_NIX_SCRIPT" -ne 0 ] ; then
+  if [ "$NEEDED_TO_SOURCE_NIX_SCRIPT" -ne 0 ]; then
     echo "$SOURCE_NIX_SCRIPT"
   fi
   echo "nix-env --upgrade"
@@ -204,29 +205,29 @@ fi
 enable_cache
 
 git_thunk() {
-    case "$1" in
-        git) echo "import ((import <nixpkgs> {}).fetchgit (builtins.fromJSON (builtins.readFile ./git.json)))" ;;
-        github) echo "import ((import <nixpkgs> {}).fetchFromGitHub (builtins.fromJSON (builtins.readFile ./github.json)))" ;;
-    esac
+  case "$1" in
+    git) echo "import ((import <nixpkgs> {}).fetchgit (builtins.fromJSON (builtins.readFile ./git.json)))" ;;
+    github) echo "import ((import <nixpkgs> {}).fetchFromGitHub (builtins.fromJSON (builtins.readFile ./github.json)))" ;;
+  esac
 }
 
 # NOTE: Returns the manifest type in OUTPUT_GIT_MANIFEST_TYPE and the manifest contents in OUTPUT_GIT_MANIFEST
 get_git_manifest() {
-    local NIX_PREFETCH_SCRIPTS="$(nix-build --no-out-link -E "(import \"$DIR/nixpkgs\" {}).nix-prefetch-scripts")"
-    local NIX="$(nix-build --no-out-link -E "(import \"$DIR/nixpkgs\" {}).nix")"
-    local REPO="$(echo "$1" | sed 's/\.git$//')"
+  local NIX_PREFETCH_SCRIPTS="$(nix-build --no-out-link -E "(import \"$DIR/nixpkgs\" {}).nix-prefetch-scripts")"
+  local NIX="$(nix-build --no-out-link -E "(import \"$DIR/nixpkgs\" {}).nix")"
+  local REPO="$(echo "$1" | sed 's/\.git$//')"
 
-    local URL="$(git -C "$REPO" config --get remote.origin.url | sed 's_^git@github.com:_git://github.com/_')" # Don't use git@github.com origins, since these can't be accessed by nix
-    local REV="$(git -C "$REPO" rev-parse HEAD)"
+  local URL="$(git -C "$REPO" config --get remote.origin.url | sed 's_^git@github.com:_git://github.com/_')" # Don't use git@github.com origins, since these can't be accessed by nix
+  local REV="$(git -C "$REPO" rev-parse HEAD)"
 
-    local GITHUB_PATTERN="^git://github.com/\([^/]*\)/\([^/]*\)$"
-    local GITHUB_ARCHIVE_URL="$(echo "$URL" | sed -n "s_${GITHUB_PATTERN}_https://github.com/\1/\2/archive/$REV.tar.gz_p")"
-    if [ -n "$GITHUB_ARCHIVE_URL" -a "$(curl -o /dev/null --silent --head --write-out '%{http_code}' "$GITHUB_ARCHIVE_URL")" -ne 404 ] ; then
-        OUTPUT_GIT_MANIFEST_TYPE=github
-        local GITHUB_OWNER="$(echo "$URL" | sed "s_${GITHUB_PATTERN}_\1_")"
-        local GITHUB_REPO="$(echo "$URL" | sed "s_${GITHUB_PATTERN}_\2_")"
-        local SHA256="$($NIX/bin/nix-prefetch-url --unpack --type sha256 "$GITHUB_ARCHIVE_URL")"
-        OUTPUT_GIT_MANIFEST="$(cat <<EOF
+  local GITHUB_PATTERN="^git://github.com/\([^/]*\)/\([^/]*\)$"
+  local GITHUB_ARCHIVE_URL="$(echo "$URL" | sed -n "s_${GITHUB_PATTERN}_https://github.com/\1/\2/archive/$REV.tar.gz_p")"
+  if [ -n "$GITHUB_ARCHIVE_URL" -a "$(curl -o /dev/null --silent --head --write-out '%{http_code}' "$GITHUB_ARCHIVE_URL")" -ne 404 ] ; then
+    OUTPUT_GIT_MANIFEST_TYPE=github
+    local GITHUB_OWNER="$(echo "$URL" | sed "s_${GITHUB_PATTERN}_\1_")"
+    local GITHUB_REPO="$(echo "$URL" | sed "s_${GITHUB_PATTERN}_\2_")"
+    local SHA256="$($NIX/bin/nix-prefetch-url --unpack --type sha256 "$GITHUB_ARCHIVE_URL")"
+    OUTPUT_GIT_MANIFEST="$(cat <<EOF
 {
   "owner": "$GITHUB_OWNER",
   "repo": "$GITHUB_REPO",
@@ -235,22 +236,22 @@ get_git_manifest() {
 }
 EOF
 )"
-    else
-        OUTPUT_GIT_MANIFEST_TYPE=git
-        OUTPUT_GIT_MANIFEST="$($NIX_PREFETCH_SCRIPTS/bin/nix-prefetch-git "$PWD/$REPO" "$REV" 2>/dev/null | sed -e '/^ *"date":/d' -e "s|$(echo "$PWD/$REPO" | sed 's/|/\\|/g')|$(echo "$URL" | sed 's/|/\\|/g')|" 2>/dev/null)"
-    fi
+  else
+    OUTPUT_GIT_MANIFEST_TYPE=git
+    OUTPUT_GIT_MANIFEST="$("$NIX_PREFETCH_SCRIPTS"/bin/nix-prefetch-git "$PWD/$REPO" "$REV" 2>/dev/null | sed -e '/^ *"date":/d' -e "s|$(echo "$PWD/$REPO" | sed 's/|/\\|/g')|$(echo "$URL" | sed 's/|/\\|/g')|" 2>/dev/null)"
+  fi
 }
 
 # Clean up a path so it can be injected into a nix expression
 cleanup_nix_path() {
-    echo "$1" | sed 's@/*$@@'
+  echo "$1" | sed 's@/*$@@'
 }
 
 prebuild_try_reflex_shell() {
-    nix-build "$DIR/shell.nix" --drv-link "$DIR/gc-roots/shell.drv" $NIXOPTS --indirect --add-root "$DIR/gc-roots/shell.out" >/dev/null
+  nix-build "$DIR/shell.nix" --drv-link "$DIR/gc-roots/shell.drv" $NIXOPTS --indirect --add-root "$DIR/gc-roots/shell.out" >/dev/null
 }
 
 try_reflex_shell() {
-    prebuild_try_reflex_shell
-    nix-shell "$DIR/gc-roots/shell.drv" $NIXOPTS "$@"
+  prebuild_try_reflex_shell
+  nix-shell "$DIR/gc-roots/shell.drv" $NIXOPTS "$@"
 }


### PR DESCRIPTION
When working in this file I discovered that indentation was all over the place: tabs, 2 spaces, 4 spaces, no indentation at all, etc. For future changes to make sense, I cleaned it up a bit.