### PR TITLE
Remove useless leftover prompt

### DIFF
--- a/common-setup.sh
+++ b/common-setup.sh
@@ -83,7 +83,7 @@ enable_cache() {
 
   mkdir -p "$user_prefs"
   if [ "$installing_nix" = false ]; then
-    read -rp "Add binary caches for reflex to $nixconf ?"
+    echo "Add binary caches for reflex to $nixconf ?"
     select yn in "Yes" "No" "Ask again next time"; do
       case $yn in
         "Yes" )


### PR DESCRIPTION
I'd expect the extra prompt to block execution on [circleci](https://github.com/reflex-frp/reflex-platform/blob/dbe16ac3a9dad7b79c48f43116ea8351c8c0b5cc/.circleci/config.yml#L16) but it doesn't seem to have any effect. 
The read prompt [doesn't even show up](https://circleci.com/gh/reflex-frp/reflex-platform/185).
I do remember seeing something along the lines of "running in non-interactive mode, assuming you would say yes" in builds before.