### PR TITLE
Fix jsaddle-warp example to work

### DIFF
--- a/docs/project-development.md
+++ b/docs/project-development.md
@@ -264,12 +264,15 @@ To use it, add `jsaddle-warp` and `reflex-dom-core` to your frontend's
 dependencies, and change `main` like so:
 
 ```haskell
-import Language.Javascript.JSaddle.Warp
-import Reflex.Dom.Core (mainWidget)
-import Reflex.Dom hiding (mainWidget)
+import qualified Language.Javascript.JSaddle.Warp as JSaddle
+import           Reflex.Dom                       hiding (mainWidget)
+import           Reflex.Dom.Core                  (mainWidget)
 
 main :: IO ()
-main = run 3911 $ mainWidget app
+main = JSaddle.run 3911 app
+
+app = mainWidget $ el "div" $ do
+ text "My app"
 ```
 
 This will spawn the Warp server on port 3911, which you can connect


### PR DESCRIPTION
- `run` has multiple occurrences, so explicitly use from `JSaddle`
- Not sure why `mainWidget` has to be moved here, but that's the only way to resolve the type error I was getting.