### PR TITLE
[WIP] Docs on setting up (Spac)emacs

### DIFF
--- a/docs/project-editor.md
+++ b/docs/project-editor.md
@@ -1,0 +1,37 @@
+# Editor setup
+
+## Spacemacs
+
+The following features are known to work in Emacs /
+[Spacemacs](https://github.com/syl20bnr/spacemacs) for developing Reflex
+applications structured around reflex-platform's
+[project](project-development.md) setup:
+
+1. Syntax highlighting
+1. GHCi repl
+1. Error navigation
+
+Firstly, Emacs must be launched from the GHC `nix-shell` so that it knows where
+to find cabal and ghci:
+
+```
+nix-shell -A shells.ghc
+> emacs
+```
+
+Now add [the haskell
+layer](https://github.com/syl20bnr/spacemacs/tree/develop/layers/+lang/haskell#install)
+to your `.spacemacs`, and then configure `haskell-mode` to use `cabal new-repl`
+by adding the following to the `dotspacemacs/user-init` function of your
+`.spacemacs` file:
+
+```
+(setq haskell-process-type 'cabal-new-repl)
+```
+
+After editing a source file you can compile and load it into ghci using
+`, s b`. This automatically launches GHCi in an Emacs buffer unless it was
+already running.
+
+Compile errors are displayed in the GHCi buffer. Use `SPC e` (and `SPC E`) to
+navigate between the corresponding source lines which produced the errors.

--- a/docs/project-editor.md
+++ b/docs/project-editor.md
@@ -28,13 +28,9 @@ nix-shell -A shells.ghc
    syntax-checking
    (haskell :variables haskell-completion-backend 'dante)
    ```
-1. Create project specific Emacs configuration by creating a `.dir-locals.el`
-   file in the root directory of your Reflex project:
+1. Configure haskell-mode to use new-style cabal commands by adding the following to the `dotspacemacs/user-config` function ;
    ```
-   ((nil . (
-     (setq haskell-process-type 'cabal-new-repl)
-     (setq dante-repl-command-line '("nix-shell" "-A" "shells.ghc" "--run" "cabal new-repl frontend"))
-   )))
+   (setq haskell-process-type 'cabal-new-repl)
    ```
 
 Restart Emacs, and access your project sources.
@@ -49,3 +45,6 @@ navigate between the corresponding source lines which produced the errors.
 Flycheck also works, which means you get immediate feedback on type errors thus
 obviating compiling and loading modules more often.
  
+Moreover you may simultaneously edit the backend and frontend sources. There
+will be two ghci buffers corresponding to each. Dante too will start independent
+ghci sessions for them.

--- a/docs/project-editor.md
+++ b/docs/project-editor.md
@@ -23,23 +23,22 @@ nix-shell -A shells.ghc
 > emacs
 ```
 
-To configure Spacemacs:
-
-1. Add the following to your `dotspacemacs-configuration-layers`:
+1. Configure Spacemacs by adding the following to your `dotspacemacs-configuration-layers`:
    ```
    syntax-checking
    (haskell :variables haskell-completion-backend 'dante)
    ```
-1. configure `haskell-mode` to use `cabal new-repl` by adding the following to
-   the `dotspacemacs/user-config` function of your `.spacemacs` file:
+1. Create project specific Emacs configuration by creating a `.dir-locals.el`
+   file in the root directory of your Reflex project (FIXME: hardcoding):
    ```
-   (setq haskell-process-type 'cabal-new-repl)
+   ((nil . (
+     (setq haskell-process-type 'cabal-new-repl)
+     (setq dante-project-root "/home/srid/code/slownews")
+     (setq dante-repl-command-line '("nix-shell" "-A" "shells.ghc" "--run" "cabal new-repl frontend"))
+   )))
    ```
-1. Configure dante to use the frontend by adding this to the `dotspacemacs/user-config` function (FIXME: avoid hardcoding paths and project)
-   ```
-   (setq dante-project-root "/home/srid/code/slownews")
-   (setq dante-repl-command-line '("nix-shell" "-A" "shells.ghc" "--run" "cabal new-repl frontend"))
-   ```
+
+Restart Emacs, and access your project sources.
 
 After editing a source file you can compile and load it into ghci using
 `, s b`. This automatically launches GHCi in an Emacs buffer unless it was

--- a/docs/project-editor.md
+++ b/docs/project-editor.md
@@ -8,11 +8,15 @@ applications structured around reflex-platform's
 [project](project-development.md) setup:
 
 - Syntax highlighting
+- All of dante functionality
+- Flycheck
 - GHCi repl
 - Error navigation
 
 Firstly, Emacs must be launched from the GHC `nix-shell` so that it knows where
-to find cabal and ghci:
+to find `runghc` (a
+[limitation](https://github.com/flycheck/flycheck-haskell/issues/65) of
+flycheck-haskell):
 
 ```
 nix-shell -A shells.ghc
@@ -21,16 +25,20 @@ nix-shell -A shells.ghc
 
 To configure Spacemacs:
 
-1. add [the haskell
-layer](https://github.com/syl20bnr/spacemacs/tree/develop/layers/+lang/haskell#install)
-to your `.spacemacs`.
-1. comment out the `syntax-checking` layer (flycheck [does not
-   work](https://github.com/flycheck/flycheck-haskell/issues/65) with new-style
-   cabal builds)
+1. Add the following to your `dotspacemacs-configuration-layers`:
+   ```
+   syntax-checking
+   (haskell :variables haskell-completion-backend 'dante)
+   ```
 1. configure `haskell-mode` to use `cabal new-repl` by adding the following to
-   the `dotspacemacs/user-init` function of your `.spacemacs` file:
+   the `dotspacemacs/user-config` function of your `.spacemacs` file:
    ```
    (setq haskell-process-type 'cabal-new-repl)
+   ```
+1. Configure dante to use the frontend by adding this to the `dotspacemacs/user-config` function (FIXME: avoid hardcoding paths and project)
+   ```
+   (setq dante-project-root "/home/srid/code/slownews")
+   (setq dante-repl-command-line '("nix-shell" "-A" "shells.ghc" "--run" "cabal new-repl frontend"))
    ```
 
 After editing a source file you can compile and load it into ghci using
@@ -39,3 +47,7 @@ already running.
 
 Compile errors are displayed in the GHCi buffer. Use `SPC e` (and `SPC E`) to
 navigate between the corresponding source lines which produced the errors.
+
+Flycheck also works, which means you get immediate feedback on type errors thus
+obviating compiling and loading modules more often.
+ 

--- a/docs/project-editor.md
+++ b/docs/project-editor.md
@@ -2,10 +2,7 @@
 
 ## Spacemacs
 
-The following features are known to work in Emacs /
-[Spacemacs](https://github.com/syl20bnr/spacemacs) for developing Reflex
-applications structured around reflex-platform's
-[project](project-development.md) setup:
+The following features are known to work in Emacs / [Spacemacs](https://github.com/syl20bnr/spacemacs) for developing Reflex applications structured around reflex-platform's [project](project-development.md) setup:
 
 - Syntax highlighting
 - All of dante functionality
@@ -13,10 +10,7 @@ applications structured around reflex-platform's
 - GHCi repl
 - Error navigation
 
-Firstly, Emacs must be launched from the GHC `nix-shell` so that it knows where
-to find `runghc` (a
-[limitation](https://github.com/flycheck/flycheck-haskell/issues/65) of
-flycheck-haskell):
+Firstly, Emacs must be launched from the GHC `nix-shell` so that it knows where to find `runghc` (a [limitation](https://github.com/flycheck/flycheck-haskell/issues/65) of flycheck-haskell):
 
 ```
 nix-shell -A shells.ghc --run emacs &
@@ -33,18 +27,10 @@ nix-shell -A shells.ghc --run emacs &
    ```
 1. Restart Emacs, and access your project sources.
 
-After editing a source file you can compile and load it into ghci using
-`, s b` (see [Spacemacs
-keybindings](https://github.com/syl20bnr/spacemacs/tree/master/layers/%2Blang/haskell#key-bindings)
-for Haskell). This automatically launches GHCi in an Emacs buffer unless it was
-already running.
+After editing a source file you can compile and load it into ghci using `, s b` (see [Spacemacs keybindings](https://github.com/syl20bnr/spacemacs/tree/master/layers/%2Blang/haskell#key-bindings) for Haskell). This automatically launches GHCi in an Emacs buffer unless it was already running.
 
-Compile errors are displayed in the GHCi buffer. Use `SPC e` (and `SPC E`) to
-navigate between the corresponding source lines which produced the errors.
+Compile errors are displayed in the GHCi buffer. Use `SPC e` (and `SPC E`) to navigate between the corresponding source lines which produced the errors.
 
-Flycheck also works, which means you get immediate feedback on type errors thus
-obviating compiling and loading modules more often.
+Flycheck also works, which means you get immediate feedback on type errors thus obviating compiling and loading modules more often.
  
-Moreover you may simultaneously edit the backend and frontend sources. There
-will be two ghci buffers corresponding to each. Dante too will start independent
-ghci sessions for them.
+Moreover you may simultaneously edit the backend and frontend sources. There will be two ghci buffers corresponding to each. Dante too will start independent ghci sessions for them.

--- a/docs/project-editor.md
+++ b/docs/project-editor.md
@@ -19,8 +19,7 @@ to find `runghc` (a
 flycheck-haskell):
 
 ```
-nix-shell -A shells.ghc
-> emacs
+nix-shell -A shells.ghc --run emacs &
 ```
 
 1. Configure Spacemacs by adding the following to your `dotspacemacs-configuration-layers`:

--- a/docs/project-editor.md
+++ b/docs/project-editor.md
@@ -27,15 +27,16 @@ nix-shell -A shells.ghc --run emacs &
    syntax-checking
    (haskell :variables haskell-completion-backend 'dante)
    ```
-1. Configure haskell-mode to use new-style cabal commands by adding the following to the `dotspacemacs/user-config` function ;
+1. Configure haskell-mode to use new-style cabal commands by adding the following to the `dotspacemacs/user-config` function:
    ```
    (setq haskell-process-type 'cabal-new-repl)
    ```
-
-Restart Emacs, and access your project sources.
+1. Restart Emacs, and access your project sources.
 
 After editing a source file you can compile and load it into ghci using
-`, s b`. This automatically launches GHCi in an Emacs buffer unless it was
+`, s b` (see [Spacemacs
+keybindings](https://github.com/syl20bnr/spacemacs/tree/master/layers/%2Blang/haskell#key-bindings)
+for Haskell). This automatically launches GHCi in an Emacs buffer unless it was
 already running.
 
 Compile errors are displayed in the GHCi buffer. Use `SPC e` (and `SPC E`) to

--- a/docs/project-editor.md
+++ b/docs/project-editor.md
@@ -7,9 +7,9 @@ The following features are known to work in Emacs /
 applications structured around reflex-platform's
 [project](project-development.md) setup:
 
-1. Syntax highlighting
-1. GHCi repl
-1. Error navigation
+- Syntax highlighting
+- GHCi repl
+- Error navigation
 
 Firstly, Emacs must be launched from the GHC `nix-shell` so that it knows where
 to find cabal and ghci:
@@ -19,15 +19,19 @@ nix-shell -A shells.ghc
 > emacs
 ```
 
-Now add [the haskell
-layer](https://github.com/syl20bnr/spacemacs/tree/develop/layers/+lang/haskell#install)
-to your `.spacemacs`, and then configure `haskell-mode` to use `cabal new-repl`
-by adding the following to the `dotspacemacs/user-init` function of your
-`.spacemacs` file:
+To configure Spacemacs:
 
-```
-(setq haskell-process-type 'cabal-new-repl)
-```
+1. add [the haskell
+layer](https://github.com/syl20bnr/spacemacs/tree/develop/layers/+lang/haskell#install)
+to your `.spacemacs`.
+1. comment out the `syntax-checking` layer (flycheck [does not
+   work](https://github.com/flycheck/flycheck-haskell/issues/65) with new-style
+   cabal builds)
+1. configure `haskell-mode` to use `cabal new-repl` by adding the following to
+   the `dotspacemacs/user-init` function of your `.spacemacs` file:
+   ```
+   (setq haskell-process-type 'cabal-new-repl)
+   ```
 
 After editing a source file you can compile and load it into ghci using
 `, s b`. This automatically launches GHCi in an Emacs buffer unless it was

--- a/docs/project-editor.md
+++ b/docs/project-editor.md
@@ -29,11 +29,10 @@ nix-shell -A shells.ghc
    (haskell :variables haskell-completion-backend 'dante)
    ```
 1. Create project specific Emacs configuration by creating a `.dir-locals.el`
-   file in the root directory of your Reflex project (FIXME: hardcoding):
+   file in the root directory of your Reflex project:
    ```
    ((nil . (
      (setq haskell-process-type 'cabal-new-repl)
-     (setq dante-project-root "/home/srid/code/slownews")
      (setq dante-repl-command-line '("nix-shell" "-A" "shells.ghc" "--run" "cabal new-repl frontend"))
    )))
    ```

--- a/docs/project-editor.md
+++ b/docs/project-editor.md
@@ -10,12 +10,14 @@ The following features are known to work in Emacs / [Spacemacs](https://github.c
 - GHCi repl
 - Error navigation
 
-Firstly, Emacs must be launched from the GHC `nix-shell` so that it knows where to find `runghc` (a [limitation](https://github.com/flycheck/flycheck-haskell/issues/65) of flycheck-haskell):
-
-```
-nix-shell -A shells.ghc --run emacs &
-```
-
+1. Install Spacemacs from its develop (not master) branch:
+   ```
+   git clone -b develop https://github.com/syl20bnr/spacemacs ~/.emacs.d
+   ```
+1. Emacs must always be launched from the GHC nix-shell of your Reflex project (flycheck [will not work](https://github.com/flycheck/flycheck-haskell/issues/65) otherwise):
+   ```
+   nix-shell -A shells.ghc --run emacs &
+   ```
 1. Configure Spacemacs by adding the following to your `dotspacemacs-configuration-layers`:
    ```
    syntax-checking
@@ -25,12 +27,16 @@ nix-shell -A shells.ghc --run emacs &
    ```
    (setq haskell-process-type 'cabal-new-repl)
    ```
-1. Restart Emacs, and access your project sources.
+1. Restart Emacs (in nix-shell), and access your project sources.
 
-After editing a source file you can compile and load it into ghci using `, s b` (see [Spacemacs keybindings](https://github.com/syl20bnr/spacemacs/tree/master/layers/%2Blang/haskell#key-bindings) for Haskell). This automatically launches GHCi in an Emacs buffer unless it was already running.
+### What should work:
 
-Compile errors are displayed in the GHCi buffer. Use `SPC e` (and `SPC E`) to navigate between the corresponding source lines which produced the errors.
+- Opening a Haskell file should automatically start the [dante](https://github.com/jyp/dante)'s GHCi in background. Play around with the dante functions (eg: `, h t` with cursor under an identifier) and make sure that they work.
 
-Flycheck also works, which means you get immediate feedback on type errors thus obviating compiling and loading modules more often.
- 
-Moreover you may simultaneously edit the backend and frontend sources. There will be two ghci buffers corresponding to each. Dante too will start independent ghci sessions for them.
+- Feedback on compile errors should appear instantaneously (without explicitly compiling) in the UI--via red squiggle underlines and mouseover popups--thanks to Flycheck.
+
+- Start a GHCi repl (which is different from that of dante) using `, s B` (see [Spacemacs keybindings](https://github.com/syl20bnr/spacemacs/tree/master/layers/%2Blang/haskell#key-bindings) for Haskell). 
+
+- Compile and load a module using `, s b`--compile errors should appear in the GHCi buffer. Use `SPC e` (and `SPC E`) to navigate between source locations for errors.
+
+- Editing both frontend and backend sources in the same Emacs session should work. dante opens *separate* GHCi processes for them, so does `, s B`. This means you will have two GHCi buffers called `*frontend*` and `*backend*`. Compiling and loading a Haskell file will use appropriate GHCi buffer.


### PR DESCRIPTION
Added to a separate markdown file under docs/. Could be merged to `project-development.md` if desired after #234 ... pretty sure the docs can be expanded in the future (vim? vscode? ...). 

[**Markdown Preview**](https://github.com/srid/reflex-platform/blob/emacs-setup/docs/project-editor.md#editor-setup)

---
The following features are known to work in Emacs / [Spacemacs](https://github.com/syl20bnr/spacemacs) for developing Reflex applications structured around reflex-platform's [project](project-development.md) setup:

- Syntax highlighting
- [Dante](https://github.com/jyp/dante) features
- Auto completion
- Flycheck
- GHCi repl
- Compile and load modules into repl
- Navigate between compile errors
- Works for both backend and frontend

## Tasks

- [x] Initial setup
- [x] Use .dir-locals.el
- [x] Don't hardcode project root in .dir-locals.el
- [x] Select package (backend vs frontend) in dante-repl-command-line
- [ ] Obviate running emacs from inside `nix-shell` (needs making flycheck work with nix cabal)