### PR TITLE
Remove JS from Github stats for this repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+ghcjs.externs.js linguist-generated


### PR DESCRIPTION
https://github.com/github/linguist#how-linguist-works

Github thinks reflex-platform is a JavaScript project (see the link above); this fixes it. Additionally it has the added benefit of suppressing diff view in PRs for this generated JS file.