### PR TITLE
Add dir-locals.nix file

### DIFF
--- a/dir-locals.nix
+++ b/dir-locals.nix
@@ -1,0 +1,4 @@
+let pkgs = import <nixpkgs> {};
+    reflex-platform = import ./. {};
+in pkgs.nixBufferBuilders.withPackages
+     (builtins.filter (p: p != null) reflex-platform.tryReflexPackages)


### PR DESCRIPTION
dir-locals.nix is a file that [nix-buffer](https://github.com/shlevy/nix-buffer) can use to setup a Nix environment within Emacs. It will set PATH and exec-path for you. This means things like Flycheck and Haskell evaluation should work out of the box.

This is how I configure it in my Emacs config:

```emacs-lisp
(use-package nix-buffer
  :commands (nix-buffer)
  :preface
  (defun turn-on-nix-buffer ()
	(when (and (not noninteractive)
		   (not (eq (aref (buffer-name) 0) ?\s))
		   (not (file-remote-p default-directory)))
	  (nix-buffer)))
  :hook (after-change-major-mode . turn-on-nix-buffer))
```

For projects outside of reflex-platform you can import from GitHub:

```nix
let pkgs = import <nixpkgs> {};
    reflex-platform = import (fetchTarball "https://github.com/reflex-frp/reflex-platform/archive/develop.tar.gz") {};
in pkgs.nixBufferBuilders.withPackages
     (builtins.filter (p: p != null) reflex-platform.tryReflexPackages)
```

Note that this is equivalent to 'try-reflex' and probably should only be used to demo reflex. Individual projects should set 'emacsBufferSetup' through Nix or just use Stack.