### PR TITLE
Override servant-auth-server version to fix build failure

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -230,6 +230,7 @@ let overrideCabal = pkg: f: if pkg == null then null else haskellLib.overrideCab
 
         base-compat = self.callHackage "base-compat" "0.9.2" {};
         constraints = self.callHackage "constraints" "0.9" {};
+        servant-auth-server = self.callHackage "servant-auth-server" "0.3.1.0" {};
         vector = doJailbreak super.vector;
         these = doJailbreak super.these;
         aeson-compat = doJailbreak super.aeson-compat;


### PR DESCRIPTION
I ran into trouble using the servant-auth-server package: 
```
Configuring servant-auth-server-0.3.0.0...
Setup: Encountered missing dependencies:
jose ==0.5.*, servant-auth ==0.2.*
builder for '/nix/store/w8w3cccjbhllq58kgcva4dcljx1cpglx-servant-auth-server-0.3.0.0.drv' failed with exit code 1
```
Bumping the version a bit seems to resolve this issue.

Three tests fail for me, but the already failed for me even without this change (cf.https://github.com/reflex-frp/reflex-platform/issues/259).