### PR TITLE
Use literate haskell in README.md

### DIFF
--- a/README.lhs
+++ b/README.lhs
@@ -1,0 +1,1 @@
+README.md

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To use Reflex Platform as a build/development system for your own projects, refe
 Important Notes
 ---------------
 
-### OS Compatibility
+ ### OS Compatibility
 
 If you're using one of these platforms, please take a look at notes before you begin:
 
@@ -23,7 +23,7 @@ If you're using one of these platforms, please take a look at notes before you b
 
 If you encounter any problems that may be specific to your platform, please submit an issue or pull request so that we can add a note for future users.
 
-### Memory Requirements
+ ### Memory Requirements
 
 GHCJS uses a lot of memory during compilation. 16GB of memory is recommended, with 8GB being pretty close to bare minimum.
 
@@ -62,16 +62,26 @@ Tutorial
 --------
 In this example, we'll be following [Luite Stegemann's lead](http://weblog.luite.com/wordpress/?p=127) and building a simple functional reactive calculator to be used in a web browser.
 
-### DOM Basics
+ ### DOM Basics
 
 Reflex's companion library, Reflex-DOM, contains a number of functions used to build and interact with the Document Object Model. Let's start by getting a basic app up and running.
 
-```haskell
-{-# LANGUAGE OverloadedStrings #-}
-import Reflex.Dom
 
-main = mainWidget $ el "div" $ text "Welcome to Reflex"
+<!--
+#ifdef SNIPPET_0
+-->
+```haskell
+
+> {-# LANGUAGE OverloadedStrings #-}
+> import Reflex.Dom
+
+> main = mainWidget $ el "div" $ text "Welcome to Reflex"
+
 ```
+<!--
+#endif
+-->
+
 
 Saving this file as `source.hs` and compiling it produces a `source.jsexe` folder (the name of the jsexe folder is based on the name of the hs file). Inside the `source.jsexe` folder you'll find `index.html`. Opening that in your browser will reveal a webpage with a single div containing the text "Welcome to Reflex".
 
@@ -85,9 +95,9 @@ el :: MonadWidget t m => Text -> m a -> m a
 
 The first argument to `el` is a `Text`, which will become the tag of the html element produced. The second argument is a `Widget`, which will become the child of the element being produced.
 
-> #### Sidebar: Interpreting the MonadWidget type
-> FRP-enabled datatypes in Reflex take an argument `t`, which identifies the FRP subsystem being used.  This ensures that wires don't get crossed if a single program uses Reflex in multiple different contexts.  You can think of `t` as identifying a particular "timeline" of the FRP system.
-> Because most simple programs will only deal with a single timeline, we won't revisit the `t` parameters in this tutorial.  As long as you make sure your `Event`, `Behavior`, and `Dynamic` values all get their `t` argument, it'll work itself out.
+ > #### Sidebar: Interpreting the MonadWidget type
+ > FRP-enabled datatypes in Reflex take an argument `t`, which identifies the FRP subsystem being used.  This ensures that wires don't get crossed if a single program uses Reflex in multiple different contexts.  You can think of `t` as identifying a particular "timeline" of the FRP system.
+ > Because most simple programs will only deal with a single timeline, we won't revisit the `t` parameters in this tutorial.  As long as you make sure your `Event`, `Behavior`, and `Dynamic` values all get their `t` argument, it'll work itself out.
 
 In our example, `el "div" $ text "Welcome to Reflex"`, the first argument to `el` was `"div"`, indicating that we are going to produce a div element.
 
@@ -99,29 +109,47 @@ text :: MonadWidget t m => Text -> m ()
 
 `text` takes a `Text` and produces a `Widget`. The `Text` becomes a text DOM node in the parent element of the `text`. Of course, instead of a `Text`, we could have used `el` here as well to continue building arbitrarily complex DOM. For instance, if we wanted to make a unordered list:
 
+<!--
+#ifdef SNIPPET_1
+-->
 ```haskell
-{-# LANGUAGE OverloadedStrings #-}
-import Reflex.Dom
 
-main = mainWidget $ el "div" $ do
-  el "p" $ text "Reflex is:"
-  el "ul" $ do
-    el "li" $ text "Efficient"
-    el "li" $ text "Higher-order"
-    el "li" $ text "Glitch-free"
+> {-# LANGUAGE OverloadedStrings #-}
+> import Reflex.Dom
+
+> main = mainWidget $ el "div" $ do
+>  el "p" $ text "Reflex is:"
+>  el "ul" $ do
+>    el "li" $ text "Efficient"
+>    el "li" $ text "Higher-order"
+>    el "li" $ text "Glitch-free"
+
 ```
+<!--
+#endif
+-->
 
-### Dynamics and Events
+
+ ### Dynamics and Events
 Of course, we want to do more than just view a static webpage. Let's start by getting some user input and printing it.
 
+<!--
+#ifdef SNIPPET_2
+-->
 ```haskell
-{-# LANGUAGE OverloadedStrings #-}
-import Reflex.Dom
 
-main = mainWidget $ el "div" $ do
-  t <- textInput def
-  dynText $ _textInput_value t
+> {-# LANGUAGE OverloadedStrings #-}
+> import Reflex.Dom
+
+> main = mainWidget $ el "div" $ do
+>   t <- textInput def
+>   dynText $ _textInput_value t
+
 ```
+<!--
+#endif
+-->
+
 
 Running this in your browser, you'll see that it produces a `div` containing an `input` element. When you type into the `input` element, the text you enter appears inside the div as well.
 
@@ -149,19 +177,27 @@ Here we are using `_textInput_value` to access the `Dynamic Text` value of the `
 
 We can also access `Event`s related to the `TextInput`. For example, consider the following code:
 
+<!--
+#ifdef SNIPPET_3
+-->
 ```haskell
-{-# LANGUAGE OverloadedStrings #-}
-import Data.Text  (pack)
-import Reflex
-import Reflex.Dom
 
-main = mainWidget $ el "div" $ do
-  t <- textInput def
-  text "Last key pressed: "
-  let keypressEvent = fmap (pack . show) $ _textInput_keypress t
-  keypressDyn <- holdDyn "None" keypressEvent
-  dynText keypressDyn
+> {-# LANGUAGE OverloadedStrings #-}
+> import Data.Text  (pack)
+> import Reflex
+> import Reflex.Dom
+
+> main = mainWidget $ el "div" $ do
+>   t <- textInput def
+>   text "Last key pressed: "
+>   let keypressEvent = fmap (pack . show) $ _textInput_keypress t
+>   keypressDyn <- holdDyn "None" keypressEvent
+>   dynText keypressDyn
+
 ```
+<!--
+#endif
+-->
 
 Here, we are creating a `TextInput` as we were before. The function `_textInput_keypress` gives us an `Event Int` representing the key code of the pressed key. We are using `fmap` here to apply `pack . show` to the `Int`, so the type of `keypressEvent` is `Event Text`. Whenever a key is pressed inside the `TextInput`, the `keypressEvent` will fire.
 `holdDyn` allows us to take create a `Dynamic` out of an `Event`. We must provide an initial value for the `Dynamic`. This will be the value of the `Dynamic` until the associated `Event` fires. The type of `holdDyn` is:
@@ -174,21 +210,29 @@ We won't go into the details of `MonadHold` here, but the rest of the type signa
 
 When you run this application, you'll see a textbox and the string "Last key pressed: None" on the screen. Recall that "None" is the initial value we gave `holdDyn`.
 
-### A Number Input
+ ### A Number Input
 A calculator was promised, I know. We'll start building the calculator by creating an input for numbers.
 
+<!--
+#ifdef SNIPPET_4
+-->
 ```haskell
-{-# LANGUAGE OverloadedStrings #-}
-import Reflex
-import Reflex.Dom
-import Data.Map (Map)
-import qualified Data.Map as Map
 
-main = mainWidget $ el "div" $ do
-  t <- textInput $ def & textInputConfig_inputType .~ "number"
-                       & textInputConfig_initialValue .~ "0"
-  dynText $ _textInput_value t
+> {-# LANGUAGE OverloadedStrings #-}
+> import Reflex
+> import Reflex.Dom
+> import Data.Map (Map)
+> import qualified Data.Map as Map
+
+> main = mainWidget $ el "div" $ do
+>   t <- textInput $ def & textInputConfig_inputType .~ "number"
+>                        & textInputConfig_initialValue .~ "0"
+>   dynText $ _textInput_value t
+
 ```
+<!--
+#endif
+-->
 
 The code above overrides some of the default values of the `TextInputConfig`. We provide a `Text` value for the `textInputConfig_inputType`, specifying the html input element's `type` attribute. We're using `"number"` here.
 
@@ -196,58 +240,75 @@ Next, we override the default initial value of the `TextInput`. We gave it `"0"`
 
 Let's do more than just take the input value and print it out. First, let's make sure the input is actually a number:
 
+<!--
+#ifdef SNIPPET_5
+-->
 ```haskell
-{-# LANGUAGE OverloadedStrings #-}
-import Reflex.Dom
-import Data.Map (Map)
-import qualified Data.Map as Map
-import Data.Text (pack, unpack)
-import Text.Read (readMaybe)
 
-main = mainWidget $ el "div" $ do
-  x <- numberInput
-  let numberString = fmap (pack . show) x
-  dynText numberString
+> {-# LANGUAGE OverloadedStrings #-}
+> import Reflex.Dom
+> import Data.Map (Map)
+> import qualified Data.Map as Map
+> import Data.Text (pack, unpack)
+> import Text.Read (readMaybe)
 
-numberInput :: MonadWidget t m => m (Dynamic t (Maybe Double))
-numberInput = do
-  n <- textInput $ def & textInputConfig_inputType .~ "number"
-                       & textInputConfig_initialValue .~ "0"
-  return . fmap (readMaybe . unpack) $ _textInput_value n
+> main = mainWidget $ el "div" $ do
+>   x <- numberInput
+>   let numberString = fmap (pack . show) x
+>   dynText numberString
+
+> numberInput :: MonadWidget t m => m (Dynamic t (Maybe Double))
+> numberInput = do
+>   n <- textInput $ def & textInputConfig_inputType .~ "number"
+>                        & textInputConfig_initialValue .~ "0"
+>   return . fmap (readMaybe . unpack) $ _textInput_value n
+
 ```
+<!--
+#endif
+-->
+
 
 We've defined a function `numberInput` that both handles the creation of the `TextInput` and reads its value. Recall that `_textInput_value` gives us a `Dynamic Text`. The final line of code in `numberInput` uses `fmap` to apply the function `readMaybe . unpack` to the `Dynamic` value of the `TextInput`. This produces a `Dynamic (Maybe Double)`. Our `main` function uses `fmap` to map over the `Dynamic (Maybe Double)` produced by `numberInput` and `pack . show` the value it contains. We store the new `Dynamic Text` in `numberString` and feed that into `dynText` to actually display the `Text`
 
 Running the app at this point should produce an input and some text showing the `Maybe Double`. Typing in a number should produce output like `Just 12.0` and typing in other text should produce the output `Nothing`.
 
-### Adding
+ ### Adding
 Now that we have `numberInput` we can put together a couple inputs to make a basic calculator.
 
+<!--
+#ifdef SNIPPET_6
+-->
 ```haskell
-{-# LANGUAGE OverloadedStrings #-}
-import Reflex
-import Reflex.Dom
-import Data.Map (Map)
-import qualified Data.Map as Map
-import Data.Text (pack, unpack)
-import Text.Read (readMaybe)
-import Control.Applicative ((<*>), (<$>))
 
-main = mainWidget $ el "div" $ do
-  nx <- numberInput
-  text " + "
-  ny <- numberInput
-  text " = "
-  let result = zipDynWith (\x y -> (+) <$> x <*> y) nx ny
-      resultString = fmap (pack . show) result
-  dynText resultString
+> {-# LANGUAGE OverloadedStrings #-}
+> import Reflex
+> import Reflex.Dom
+> import Data.Map (Map)
+> import qualified Data.Map as Map
+> import Data.Text (pack, unpack)
+> import Text.Read (readMaybe)
+> import Control.Applicative ((<*>), (<$>))
+>
+> main = mainWidget $ el "div" $ do
+>   nx <- numberInput
+>   text " + "
+>   ny <- numberInput
+>   text " = "
+>   let result = zipDynWith (\x y -> (+) <$> x <*> y) nx ny
+>       resultString = fmap (pack . show) result
+>   dynText resultString
 
-numberInput :: MonadWidget t m => m (Dynamic t (Maybe Double))
-numberInput = do
-  n <- textInput $ def & textInputConfig_inputType .~ "number"
-                       & textInputConfig_initialValue .~ "0"
-  return . fmap (readMaybe . unpack) $ _textInput_value n
+> numberInput :: MonadWidget t m => m (Dynamic t (Maybe Double))
+> numberInput = do
+>   n <- textInput $ def & textInputConfig_inputType .~ "number"
+>                        & textInputConfig_initialValue .~ "0"
+>   return . fmap (readMaybe . unpack) $ _textInput_value n
+
 ```
+<!--
+#endif
+-->
 
 `numberInput` hasn't changed here. Our `main` function now creates two inputs. `zipDynWith` is used to produce the actual sum of the values of the inputs. The type signature of `zipDynWith` is:
 
@@ -261,7 +322,7 @@ In our case, `zipDynWith` is combining the results of our two `numberInput`s (wi
 
 We use `fmap` again to apply `pack . show` to `result` (a `Dynamic (Maybe Double)`) resulting in a `Dynamic Text`. This `resultText` is then displayed using `dynText`.
 
-### Supporting Multiple Operations
+ ### Supporting Multiple Operations
 Next, we'll add support for other operations. We're going to add a dropdown so that the user can select the operation to apply. The function `dropdown` has the type:
 
 ```haskell
@@ -286,44 +347,52 @@ d <- dropdown Times (constDyn ops) def
 
 We are using `constDyn` again here to turn our `Map` of operations into a `Dynamic`. Using `def`, we provide the default `DropdownConfig`. The result, `d`, will be a `Dropdown`. We can retrieve the `Dynamic` selection of a `Dropdown` by using `_dropdown_value`.
 
+<!--
+#ifdef SNIPPET_7
+-->
 ```haskell
-{-# LANGUAGE OverloadedStrings #-}
-import Reflex
-import Reflex.Dom
-import Data.Map (Map)
-import qualified Data.Map as Map
-import Data.Text (pack, unpack, Text)
-import Text.Read (readMaybe)
-import Control.Applicative ((<*>), (<$>))
 
-main = mainWidget $ el "div" $ do
-  nx <- numberInput
-  d <- dropdown Times (constDyn ops) def
-  ny <- numberInput
-  let values = zipDynWith (,) nx ny
-      result = zipDynWith (\o (x,y) -> runOp o <$> x <*> y) (_dropdown_value d) values
-      resultText = fmap (pack . show) result
-  text " = "
-  dynText resultText
+> {-# LANGUAGE OverloadedStrings #-}
+> import Reflex
+> import Reflex.Dom
+> import Data.Map (Map)
+> import qualified Data.Map as Map
+> import Data.Text (pack, unpack, Text)
+> import Text.Read (readMaybe)
+> import Control.Applicative ((<*>), (<$>))
+>
+> main = mainWidget $ el "div" $ do
+>   nx <- numberInput
+>   d <- dropdown Times (constDyn ops) def
+>   ny <- numberInput
+>   let values = zipDynWith (,) nx ny
+>       result = zipDynWith (\o (x,y) -> runOp o <$> x <*> y) (_dropdown_value d) values
+>       resultText = fmap (pack . show) result
+>   text " = "
+>   dynText resultText
+>
+> numberInput :: MonadWidget t m => m (Dynamic t (Maybe Double))
+> numberInput = do
+>   n <- textInput $ def & textInputConfig_inputType .~ "number"
+>                        & textInputConfig_initialValue .~ "0"
+>   return . fmap (readMaybe . unpack) $ _textInput_value n
+>
+> data Op = Plus | Minus | Times | Divide deriving (Eq, Ord)
+>
+> ops :: Map Op Text
+> ops = Map.fromList [(Plus, "+"), (Minus, "-"), (Times, "*"), (Divide, "/")]
+>
+> runOp :: Fractional a => Op -> a -> a -> a
+> runOp s = case s of
+>             Plus -> (+)
+>             Minus -> (-)
+>             Times -> (*)
+>             Divide -> (/)
 
-numberInput :: MonadWidget t m => m (Dynamic t (Maybe Double))
-numberInput = do
-  n <- textInput $ def & textInputConfig_inputType .~ "number"
-                       & textInputConfig_initialValue .~ "0"
-  return . fmap (readMaybe . unpack) $ _textInput_value n
-
-data Op = Plus | Minus | Times | Divide deriving (Eq, Ord)
-
-ops :: Map Op Text
-ops = Map.fromList [(Plus, "+"), (Minus, "-"), (Times, "*"), (Divide, "/")]
-
-runOp :: Fractional a => Op -> a -> a -> a
-runOp s = case s of
-            Plus -> (+)
-            Minus -> (-)
-            Times -> (*)
-            Divide -> (/)
 ```
+<!--
+#endif
+-->
 
 This is our complete program. We've added an uninteresting function `runOp`
 that takes an `Op` and returns an operation. The keys of the `Map` we used
@@ -337,7 +406,7 @@ Next, we call `zipDynWith` again, combining the `_dropdown_value` and `values`. 
 
 Running the app at this point will give us our two number inputs with a dropdown of operations sandwiched between them. Multiplication should be pre-selected when the page loads.
 
-### Dynamic Element Attributes
+ ### Dynamic Element Attributes
 Let's spare a thought for the user of our calculator and add a little UI styling. Our number input currently looks like this:
 
 ```haskell
@@ -387,49 +456,57 @@ After we bind `result`, we use `fmap` again to apply a switching function to `re
 
 The complete program now looks like this:
 
+<!--
+#ifdef SNIPPET_8
+-->
 ```haskell
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecursiveDo       #-}
-import Reflex
-import Reflex.Dom
-import Data.Map (Map)
-import qualified Data.Map as Map
-import Data.Text (pack, unpack, Text)
-import Text.Read (readMaybe)
-import Control.Applicative ((<*>), (<$>))
 
-main = mainWidget $ el "div" $ do
-  nx <- numberInput
-  d <- dropdown Times (constDyn ops) def
-  ny <- numberInput
-  let values = zipDynWith (,) nx ny
-      result = zipDynWith (\o (x,y) -> runOp o <$> x <*> y) (_dropdown_value d) values
-      resultText = fmap (pack . show) result
-  text " = "
-  dynText resultText
+> {-# LANGUAGE OverloadedStrings #-}
+> {-# LANGUAGE RecursiveDo       #-}
+> import Reflex
+> import Reflex.Dom
+> import Data.Map (Map)
+> import qualified Data.Map as Map
+> import Data.Text (pack, unpack, Text)
+> import Text.Read (readMaybe)
+> import Control.Applicative ((<*>), (<$>))
+>
+> main = mainWidget $ el "div" $ do
+>   nx <- numberInput
+>   d <- dropdown Times (constDyn ops) def
+>   ny <- numberInput
+>   let values = zipDynWith (,) nx ny
+>       result = zipDynWith (\o (x,y) -> runOp o <$> x <*> y) (_dropdown_value d) values
+>       resultText = fmap (pack . show) result
+>   text " = "
+>   dynText resultText
+>
+> numberInput :: (MonadWidget t m) => m (Dynamic t (Maybe Double))
+> numberInput = do
+>   let errorState = "style" =: "border-color: red"
+>       validState = "style" =: "border-color: green"
+>   rec n <- textInput $ def & textInputConfig_inputType .~ "number"
+>                            & textInputConfig_initialValue .~ "0"
+>                            & textInputConfig_attributes .~ attrs
+>       let result = fmap (readMaybe . unpack) $ _textInput_value n
+>           attrs  = fmap (maybe errorState (const validState)) result
+>   return result
+>
+> data Op = Plus | Minus | Times | Divide deriving (Eq, Ord)
+>
+> ops :: Map Op Text
+> ops = Map.fromList [(Plus, "+"), (Minus, "-"), (Times, "*"), (Divide, "/")]
+>
+> runOp :: Fractional a => Op -> a -> a -> a
+> runOp s = case s of
+>             Plus -> (+)
+>             Minus -> (-)
+>             Times -> (*)
+>             Divide -> (/)
 
-numberInput :: (MonadWidget t m) => m (Dynamic t (Maybe Double))
-numberInput = do
-  let errorState = "style" =: "border-color: red"
-      validState = "style" =: "border-color: green"
-  rec n <- textInput $ def & textInputConfig_inputType .~ "number"
-                           & textInputConfig_initialValue .~ "0"
-                           & textInputConfig_attributes .~ attrs
-      let result = fmap (readMaybe . unpack) $ _textInput_value n
-          attrs  = fmap (maybe errorState (const validState)) result
-  return result
-
-data Op = Plus | Minus | Times | Divide deriving (Eq, Ord)
-
-ops :: Map Op Text
-ops = Map.fromList [(Plus, "+"), (Minus, "-"), (Times, "*"), (Divide, "/")]
-
-runOp :: Fractional a => Op -> a -> a -> a
-runOp s = case s of
-            Plus -> (+)
-            Minus -> (-)
-            Times -> (*)
-            Divide -> (/)
 ```
+<!--
+#endif
+-->
 
 The input border colors will now change depending on their value.

--- a/test.hs
+++ b/test.hs
@@ -26,6 +26,20 @@ main = hspec $ parallel $ do
             writefile (fromText helloFilename) "{-# LANGUAGE OverloadedStrings #-}\nimport Reflex.Dom\nmain = mainWidget $ text \"Hello, world!\""
             run (d </> ("try-reflex" :: String)) ["--pure", "--command", fromString platform <> flags <> " " <> helloFilename <> " ; exit $?"] -- The "exit $?" will no longer be needed when we can assume users will have this patch: https://github.com/NixOS/nix/commit/7ba0e9cb481f00baca02f31393ad49681fc48a5d
         return () :: IO ()
+  describe "readme" $ do
+    forM_ ["ghc", "ghcjs"] $ \platform -> do
+      forM_ [0..8] $ \i -> do
+        it ("snippet_" <> show i <> " can be built by " <> platform) $ do
+          shelly $ silently $ do
+            os <- T.stripEnd <$> run "uname" ["-s"]
+            d <- pwd
+            let flags = if os == "Darwin" then " -dynamic" else ""
+                filename = "README.lhs" :: String
+            withTmpDir $ \tmp -> do
+              cp (d </> filename) tmp
+              cd tmp
+              run (d </> ("try-reflex" :: String)) ["--pure", "--command", fromString platform <> flags <> " README.lhs -cpp -DSNIPPET_" <> fromString (show i)]
+          return () :: IO ()
   describe "work-on" $ do
     -- Test that the work-on shell can build the core reflex libraries in a variety of configurations
     forM_ ["ghc", "ghcjs"] $ \platform -> do


### PR DESCRIPTION
As of now, this is more a proof-of-concept than anything else.
The app snippets in README.md (.lhs) are embedded in literate haskell and built using the test suite (which in turn is run by CI).
The overall goal is to get the ball rolling on discussing/enforcing that docs/tutorials stay updated and compilable/executable as much as possible.

Here, I tried out the approach from https://github.com/tomsmalley/quickform#example : 
use [bird-style LH](https://wiki.haskell.org/Literate_programming#Bird_Style) directly on the markdown file.

Another possibility is using something like https://github.com/sol/markdown-unlit instead of the default unlit. This needs more initial setup, but lets us avoid signal character annoyances (e.g. whitespace before `###`, `>` before every line of code) by using markdown code blocks as literate code blocks, like in [latex style LH](https://wiki.haskell.org/Literate_programming#Latex_suggestions_for_literate_programming). 
I assume this also allows use of CPP, which is abused in this PR to allow multiple `main` functions via directives-inside-comments that are (github)markdown-invisible, but ghc-visible

Both these options try to address the doc rot problem while keeping the code 'renderable' in the repository hosting service. 
For docs hosted elsewhere (e.g. https://github.com/reflex-frp/reflex-frp.org), we can do pretty much anything.
Some discussion on that approach already happened in #234.