### PR TITLE
minSdkVersion down to 21 which should be Android 5

### DIFF
--- a/android/AndroidManifest.xml.nix
+++ b/android/AndroidManifest.xml.nix
@@ -29,7 +29,6 @@
         </activity>
         ${services}
     </application>
-    <uses-sdk android:minSdkVersion="21" />
     <uses-permission android:name="android.permission.INTERNET" />
     ${permissions}
 </manifest>

--- a/android/AndroidManifest.xml.nix
+++ b/android/AndroidManifest.xml.nix
@@ -29,9 +29,8 @@
         </activity>
         ${services}
     </application>
-    <uses-sdk android:minSdkVersion="25" />
+    <uses-sdk android:minSdkVersion="21" />
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     ${permissions}
 </manifest>
 ''


### PR DESCRIPTION
Also get rid of not needed WRITE_EXTERNAL_STORAGE permission.

I tested this successfully with Android 5, so there is no reason to not show the
application on Google Play for users of Android 5, 6 and 7.0.