### PR TITLE
Bump jsaddle

### DIFF
--- a/jsaddle/github.json
+++ b/jsaddle/github.json
@@ -1,6 +1,6 @@
 {
-  "owner": "reflex-frp",
+  "owner": "ghcjs",
   "repo": "jsaddle",
-  "rev": "102dc862dc77d1897f5b62f19f50c2f3f6a94dcc",
-  "sha256": "0wkpfh3q4qaq9vgzj5l14pxg33ig8dcddadd8126m4q7g5h3va94"
+  "rev": "50126cdcc15caeecb5910a15ac6cb67e3ab638ae",
+  "sha256": "0pnn36h6a8sfwhhf34px6a1lvzr447p7z0r0ky7shv7d78awfvgc"
 }


### PR DESCRIPTION
- commits from previous pointed [fork](https://github.com/reflex-frp/jsaddle/commit/102dc862dc77d1897f5b62f19f50c2f3f6a94dcc) have been merged upstream
- fixes jsaddle build when not using text-jsstring overrides https://github.com/reflex-frp/reflex-platform/issues/214#issuecomment-371633167