### PR TITLE
Allow the tools to be overridden.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -652,7 +652,7 @@ in let this = rec {
     inherit (nativeHaskellPackages) stylish-haskell; # Recent stylish-haskell only builds with AMP in place
   });
 
-  generalDevTools = haskellPackages: builtins.attrValues (generalDevTools haskellPackages);
+  generalDevTools = haskellPackages: builtins.attrValues (generalDevToolsAttrs haskellPackages);
 
   nativeHaskellPackages = haskellPackages:
     if haskellPackages.isGhcjs or false

--- a/default.nix
+++ b/default.nix
@@ -663,7 +663,7 @@ in let this = rec {
     buildDepends = (drv.buildDepends or []) ++ generalDevTools (nativeHaskellPackages haskellPackages);
   })).env;
 
-  workOnMulti' = { env, packageNames, tools ? _: [], toolOverrides ? _: _: {} }:
+  workOnMulti' = { env, packageNames, tools ? _: [], shellToolOverrides ? _: _: {} }:
     let ghcEnv =
       let inherit (builtins) filter all concatLists;
           dependenciesOf = x: (x.buildDepends or [])
@@ -678,7 +678,7 @@ in let this = rec {
           })).out;
       in env.ghc.withPackages (pkgEnv: concatLists (map (overiddenOut pkgEnv) packageNames));
     baseTools = generalDevToolsAttrs env;
-    overriddenTools = baseTools // toolOverrides env baseTools;
+    overriddenTools = baseTools // shellToolOverrides env baseTools;
 
     in nixpkgs.runCommand "shell" (ghcEnv.ghcEnvVars // {
       buildInputs = [

--- a/default.nix
+++ b/default.nix
@@ -191,7 +191,7 @@ let iosSupport =
       shims = hackGet ./shims;
       ghcjs = hackGet ./ghcjs;
     };
-    inherit (nixpkgs.stdenv.lib) optional optionals;
+    inherit (nixpkgs.stdenv.lib) optional optionals optionalAttrs;
     optionalExtension = cond: overlay: if cond then overlay else _: _: {};
 in with haskellLib;
 let overrideCabal = pkg: f: if pkg == null then null else haskellLib.overrideCabal pkg f;
@@ -627,28 +627,32 @@ in let this = rec {
   ];
 
   # Tools that are useful for development under both ghc and ghcjs
-  generalDevTools = haskellPackages:
+  generalDevToolsAttrs = haskellPackages:
     let nativeHaskellPackages = ghc;
-    in [
-    nativeHaskellPackages.Cabal
-    nativeHaskellPackages.cabal-install
-    nativeHaskellPackages.ghcid
-    nativeHaskellPackages.hasktags
-    nativeHaskellPackages.hlint
-    nixpkgs.cabal2nix
-    nixpkgs.curl
-    nixpkgs.nix-prefetch-scripts
-    nixpkgs.nodejs
-    nixpkgs.pkgconfig
-    nixpkgs.closurecompiler
-  ] ++ (optionals (!(haskellPackages.ghc.isGhcjs or false) && builtins.compareVersions haskellPackages.ghc.version "8.2" < 0) [
+    in {
+    inherit (nativeHaskellPackages)
+      Cabal
+      cabal-install
+      ghcid
+      hasktags
+      hlint;
+    inherit (nixpkgs)
+      cabal2nix
+      curl
+      nix-prefetch-scripts
+      nodejs
+      pkgconfig
+      closurecompiler;
+  } // (optionalAttrs (!(haskellPackages.ghc.isGhcjs or false) && builtins.compareVersions haskellPackages.ghc.version "8.2" < 0) {
     # ghc-mod doesn't currently work on ghc 8.2.2; revisit when https://github.com/DanielG/ghc-mod/pull/911 is closed
     # When ghc-mod is included in the environment without being wrapped in justStaticExecutables, it prevents ghc-pkg from seeing the libraries we install
-    (nixpkgs.haskell.lib.justStaticExecutables nativeHaskellPackages.ghc-mod)
-    haskellPackages.hdevtools
-  ]) ++ (if builtins.compareVersions haskellPackages.ghc.version "7.10" >= 0 then [
-    nativeHaskellPackages.stylish-haskell # Recent stylish-haskell only builds with AMP in place
-  ] else []);
+    ghc-mod = (nixpkgs.haskell.lib.justStaticExecutables nativeHaskellPackages.ghc-mod);
+    inherit (haskellPackages) hdevtools;
+  }) // (optionalAttrs (builtins.compareVersions haskellPackages.ghc.version "7.10" >= 0) {
+    inherit (nativeHaskellPackages) stylish-haskell; # Recent stylish-haskell only builds with AMP in place
+  });
+
+  generalDevTools = haskellPackages: builtins.attrValues (generalDevTools haskellPackages);
 
   nativeHaskellPackages = haskellPackages:
     if haskellPackages.isGhcjs or false
@@ -659,7 +663,7 @@ in let this = rec {
     buildDepends = (drv.buildDepends or []) ++ generalDevTools (nativeHaskellPackages haskellPackages);
   })).env;
 
-  workOnMulti' = { env, packageNames, tools ? _: [] }:
+  workOnMulti' = { env, packageNames, tools ? _: [], toolOverrides ? _: _: {} }:
     let ghcEnv =
       let inherit (builtins) filter all concatLists;
           dependenciesOf = x: (x.buildDepends or [])
@@ -673,11 +677,13 @@ in let this = rec {
             };
           })).out;
       in env.ghc.withPackages (pkgEnv: concatLists (map (overiddenOut pkgEnv) packageNames));
+    baseTools = generalDevToolsAttrs env;
+    overriddenTools = baseTools // toolOverrides env baseTools;
 
     in nixpkgs.runCommand "shell" (ghcEnv.ghcEnvVars // {
       buildInputs = [
         ghcEnv
-      ] ++ generalDevTools env ++ tools env;
+      ] ++ builtins.attrValues overriddenTools ++ tools env;
     }) "";
 
   workOnMulti = env: packageNames: workOnMulti' { inherit env packageNames; };

--- a/project/default.nix
+++ b/project/default.nix
@@ -86,19 +86,32 @@ in
   #       }) {};
   #     };
 
-, tools ? _: []
-  # A function returning the list of tools to provide in the
+, toolOverrides ? _: _: {}
+  # A function returning a record of tools to provide in the
   # nix-shells.
   #
-  #     tools = ghc: with ghc; [
-  #       hpack
-  #       pkgs.chromium
-  #     ];
+  #     toolOverrides = ghc: super: {
+  #       inherit (ghc) hpack;
+  #       inherit (pkgs) chromium;
+  #       ghc-mod = null;
+  #       cabal-install = ghc.callHackage "cabal-install" "2.0.0.1" {};
+  #       ghcid = pkgs.haskell.lib.justStaticExecutables super.ghcid;
+  #     };
   #
   # Some tools, like `ghc-mod`, have to be built with the same GHC as
   # your project. The argument to the `tools` function is the haskell
   # package set of the platform we are developing for, allowing you to
   # build tools with the correct Haskell package set.
+  #
+  # The second argument, `super`, is the record of tools provided by
+  # default. You can override these defaults by returning values with
+  # the same name in your record. They can be disabled by setting them
+  # to null.
+
+, tools ? _: []
+  # An older, obsolete version of `toolOverrides`.
+  #
+  #     tools = ghc: with ghc; [ hpack pkgs.chromium ];
 
 , withHoogle ? true
   # Set to false to disable building the hoogle database when entering
@@ -147,7 +160,7 @@ let
           ghcWithPackages = self.ghcWithHoogle;
         }; };
         packageNames = pnames;
-        inherit tools;
+        inherit tools toolOverrides;
       }
     ) shells;
 

--- a/project/default.nix
+++ b/project/default.nix
@@ -86,11 +86,11 @@ in
   #       }) {};
   #     };
 
-, toolOverrides ? _: _: {}
+, shellToolOverrides ? _: _: {}
   # A function returning a record of tools to provide in the
   # nix-shells.
   #
-  #     toolOverrides = ghc: super: {
+  #     shellToolOverrides = ghc: super: {
   #       inherit (ghc) hpack;
   #       inherit (pkgs) chromium;
   #       ghc-mod = null;
@@ -109,7 +109,7 @@ in
   # to null.
 
 , tools ? _: []
-  # An older, obsolete version of `toolOverrides`.
+  # An older, obsolete version of `shellToolOverrides`.
   #
   #     tools = ghc: with ghc; [ hpack pkgs.chromium ];
 
@@ -160,7 +160,7 @@ let
           ghcWithPackages = self.ghcWithHoogle;
         }; };
         packageNames = pnames;
-        inherit tools toolOverrides;
+        inherit tools shellToolOverrides;
       }
     ) shells;
 


### PR DESCRIPTION
This allows projects derived from reflex-project-skeleton to upgrade the
version of cabal-install and other tools.

Resolves #276