### PR TITLE
Add missing 'set -euo pipefail'

### DIFF
--- a/scripts/run-todomvc-in-ios-sim.sh
+++ b/scripts/run-todomvc-in-ios-sim.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 function cleanup {
   if [ -n "$uuid" ]; then


### PR DESCRIPTION
Prevents trying to build todo-mvc twice in case of failure