### PR TITLE
Provide path to ghcjs externs at top level

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -717,4 +717,5 @@ in let this = rec {
   project = args: import ./project this (args ({ pkgs = nixpkgs; } // this));
   tryReflexShell = pinBuildInputs ("shell-" + system) tryReflexPackages [];
   js-framework-benchmark-src = hackGet ./js-framework-benchmark;
+  ghcjsExternsJs = ./ghcjs.externs.js;
 }; in this


### PR DESCRIPTION
makes it more convenient to access when working with thunks