### PR TITLE
Superficial backports from reunification 

### DIFF
--- a/android/default.nix
+++ b/android/default.nix
@@ -1,8 +1,8 @@
 env@{
   nixpkgs
 , nixpkgsCross
-, ghcAndroidArm64
-, ghcAndroidArmv7a
+, ghcAndroidAarch64
+, ghcAndroidAarch32
 , overrideCabal
 }:
 with nixpkgs.lib.strings;

--- a/android/impl.nix
+++ b/android/impl.nix
@@ -44,12 +44,12 @@ in {
             hsApp = overrideAndroidCabal (package myHaskellPackages);
           }) {
             "arm64-v8a" = {
-              myNixpkgs = nixpkgsCross.android.arm64Impure;
-              myHaskellPackages = ghcAndroidArm64;
+              myNixpkgs = nixpkgsCross.android.aarch64;
+              myHaskellPackages = ghcAndroidAarch64;
             };
             "armeabi-v7a" = {
-              myNixpkgs = nixpkgsCross.android.armv7aImpure;
-              myHaskellPackages = ghcAndroidArmv7a;
+              myNixpkgs = nixpkgsCross.android.aarch32;
+              myHaskellPackages = ghcAndroidAarch32;
             };
           };
           abiVersions = attrNames appSOs;
@@ -73,8 +73,8 @@ in {
         javaSrc = nixpkgs.buildEnv {
           name = applicationId + "-java";
           paths = [
-            (ghcAndroidArm64.android-activity.src + "/java") #TODO: Use output, not src
-            (ghcAndroidArm64.reflex-dom.src + "/java")
+            (ghcAndroidAarch64.android-activity.src + "/java") #TODO: Use output, not src
+            (ghcAndroidAarch64.reflex-dom.src + "/java")
           ];
         };
         src = ./src;

--- a/default.nix
+++ b/default.nix
@@ -16,7 +16,7 @@ let iosSupport =
       if system != "x86_64-darwin" then false
       else if iosSupportForce || builtins.pathExists iosSdkLocation then true
       else lib.warn "No iOS sdk found at ${iosSdkLocation}; iOS support disabled.  To enable, either install a version of Xcode that provides that SDK or override the value of iosSdkVersion to match your installed version." false;
-    androidSupport = nixpkgs.stdenv.hostPlatform.isLinux && nixpkgs.stdenv.hostPlatform.isx86;
+    androidSupport = lib.elem system [ "x86_64-linux" ];
     globalOverlays = [
       (self: super: {
         all-cabal-hashes = super.all-cabal-hashes.override {

--- a/default.nix
+++ b/default.nix
@@ -427,42 +427,42 @@ let overrideCabal = pkg: f: if pkg == null then null else haskellLib.overrideCab
       (optionalExtension useTextJSString haskellOverlays.textJSString)
     ];
   };
-  ghcHEAD = (makeRecursivelyOverridable nixpkgs.pkgs.haskell.packages.ghcHEAD).override {
+  ghcHEAD = (makeRecursivelyOverridable nixpkgs.haskell.packages.ghcHEAD).override {
     overrides = lib.foldr lib.composeExtensions (_: _: {}) [
       extendHaskellPackages
       (optionalExtension enableExposeAllUnfoldings haskellOverlays.exposeAllUnfoldings)
       haskellOverlays.ghc-head
     ];
   };
-  ghc8_2_1 = (makeRecursivelyOverridable nixpkgs.pkgs.haskell.packages.ghc821).override {
+  ghc8_2_1 = (makeRecursivelyOverridable nixpkgs.haskell.packages.ghc821).override {
     overrides = lib.foldr lib.composeExtensions (_: _: {}) [
       extendHaskellPackages
       (optionalExtension enableExposeAllUnfoldings haskellOverlays.exposeAllUnfoldings)
       haskellOverlays.ghc-8_2_1
     ];
   };
-  ghc = (makeRecursivelyOverridable nixpkgs.pkgs.haskell.packages.ghc802).override {
+  ghc = (makeRecursivelyOverridable nixpkgs.haskell.packages.ghc802).override {
     overrides = lib.foldr lib.composeExtensions (_: _: {}) [
       extendHaskellPackages
       (optionalExtension enableExposeAllUnfoldings haskellOverlays.exposeAllUnfoldings)
       haskellOverlays.ghc-8
     ];
   };
-  ghc7 = (makeRecursivelyOverridable nixpkgs.pkgs.haskell.packages.ghc7103).override {
+  ghc7 = (makeRecursivelyOverridable nixpkgs.haskell.packages.ghc7103).override {
     overrides = lib.foldr lib.composeExtensions (_: _: {}) [
       extendHaskellPackages
       (optionalExtension enableExposeAllUnfoldings haskellOverlays.exposeAllUnfoldings)
       haskellOverlays.ghc-7
     ];
   };
-  ghc7_8 = (makeRecursivelyOverridable nixpkgs.pkgs.haskell.packages.ghc784).override {
+  ghc7_8 = (makeRecursivelyOverridable nixpkgs.haskell.packages.ghc784).override {
     overrides = lib.foldr lib.composeExtensions (_: _: {}) [
       extendHaskellPackages
       (optionalExtension enableExposeAllUnfoldings haskellOverlays.exposeAllUnfoldings)
       haskellOverlays.ghc-7_8
     ];
   };
-  ghcAndroidAarch64 = (makeRecursivelyOverridable nixpkgsCross.android.aarch64.pkgs.haskell.packages.ghc821).override {
+  ghcAndroidAarch64 = (makeRecursivelyOverridable nixpkgsCross.android.aarch64.haskell.packages.ghc821).override {
     overrides = lib.foldr lib.composeExtensions (_: _: {}) [
       extendHaskellPackages
       (optionalExtension enableExposeAllUnfoldings haskellOverlays.exposeAllUnfoldings)
@@ -471,7 +471,7 @@ let overrideCabal = pkg: f: if pkg == null then null else haskellLib.overrideCab
       haskellOverlays.android
     ];
   };
-  ghcAndroidAarch32 = (makeRecursivelyOverridable nixpkgsCross.android.armv7aImpure.pkgs.haskell.packages.ghc821).override {
+  ghcAndroidAarch32 = (makeRecursivelyOverridable nixpkgsCross.android.armv7aImpure.haskell.packages.ghc821).override {
     overrides = lib.foldr lib.composeExtensions (_: _: {}) [
       extendHaskellPackages
       (optionalExtension enableExposeAllUnfoldings haskellOverlays.exposeAllUnfoldings)
@@ -480,14 +480,14 @@ let overrideCabal = pkg: f: if pkg == null then null else haskellLib.overrideCab
       haskellOverlays.android
     ];
   };
-  ghcIosSimulator64 = (makeRecursivelyOverridable nixpkgsCross.ios.simulator64.pkgs.haskell.packages.ghc821).override {
+  ghcIosSimulator64 = (makeRecursivelyOverridable nixpkgsCross.ios.simulator64.haskell.packages.ghc821).override {
     overrides = lib.foldr lib.composeExtensions (_: _: {}) [
       extendHaskellPackages
       (optionalExtension enableExposeAllUnfoldings haskellOverlays.exposeAllUnfoldings)
       haskellOverlays.ghc-8_2_1
     ];
   };
-  ghcIosAarch64 = (makeRecursivelyOverridable nixpkgsCross.ios.aarch64.pkgs.haskell.packages.ghc821).override {
+  ghcIosAarch64 = (makeRecursivelyOverridable nixpkgsCross.ios.aarch64.haskell.packages.ghc821).override {
     overrides = lib.foldr lib.composeExtensions (_: _: {}) [
       extendHaskellPackages
       (optionalExtension enableExposeAllUnfoldings haskellOverlays.exposeAllUnfoldings)
@@ -496,7 +496,7 @@ let overrideCabal = pkg: f: if pkg == null then null else haskellLib.overrideCab
       haskellOverlays.ios
     ];
   };
-  ghcIosAarch32 = (makeRecursivelyOverridable nixpkgsCross.ios.armv7.pkgs.haskell.packages.ghc821).override {
+  ghcIosAarch32 = (makeRecursivelyOverridable nixpkgsCross.ios.armv7.haskell.packages.ghc821).override {
     overrides = lib.foldr lib.composeExtensions (_: _: {}) [
       extendHaskellPackages
       (optionalExtension enableExposeAllUnfoldings haskellOverlays.exposeAllUnfoldings)

--- a/default.nix
+++ b/default.nix
@@ -15,7 +15,7 @@
 let iosSupport =
       if system != "x86_64-darwin" then false
       else if iosSupportForce || builtins.pathExists iosSdkLocation then true
-      else builtins.trace "Warning: No iOS sdk found at ${iosSdkLocation}; iOS support disabled.  To enable, either install a version of Xcode that provides that SDK or override the value of iosSdkVersion to match your installed version." false;
+      else lib.warn "No iOS sdk found at ${iosSdkLocation}; iOS support disabled.  To enable, either install a version of Xcode that provides that SDK or override the value of iosSdkVersion to match your installed version." false;
     androidSupport = nixpkgs.stdenv.hostPlatform.isLinux && nixpkgs.stdenv.hostPlatform.isx86;
     globalOverlays = [
       (self: super: {
@@ -59,7 +59,7 @@ let iosSupport =
     inherit (nixpkgs) lib fetchurl fetchgit fetchgitPrivate fetchFromGitHub;
     nixpkgsCross = {
       android = lib.mapAttrs (_: args: if args == null then null else nixpkgsFunc args) rec {
-        arm64 = {
+        aarch64 = rec {
           system = "x86_64-linux";
           overlays = globalOverlays;
           crossSystem = {
@@ -69,13 +69,11 @@ let iosSupport =
             withTLS = true;
             openssl.system = "linux-generic64";
             platform = nixpkgs.pkgs.platforms.aarch64-multiplatform;
+            useAndroidPrebuilt = true;
           };
           config.allowUnfree = true;
         };
-        arm64Impure = arm64 // {
-          crossSystem = arm64.crossSystem // { useAndroidPrebuilt = true; };
-        };
-        armv7a = {
+        aarch32 = {
           system = "x86_64-linux";
           overlays = globalOverlays;
           crossSystem = {
@@ -85,12 +83,15 @@ let iosSupport =
             withTLS = true;
             openssl.system = "linux-generic32";
             platform = nixpkgs.pkgs.platforms.armv7l-hf-multiplatform;
+            useAndroidPrebuilt = true;
           };
           config.allowUnfree = true;
         };
-        armv7aImpure = armv7a // {
-          crossSystem = armv7a.crossSystem // { useAndroidPrebuilt = true; };
-        };
+        # Back compat
+        arm64 = lib.warn "nixpkgsCross.android.arm64 has been deprecated, using nixpkgsCross.android.aarch64 instead." aarch64;
+        armv7a = lib.warn "nixpkgsCross.android.armv7a has been deprecated, using nixpkgsCross.android.aarch32 instead." aarch32;
+        arm64Impure = lib.warn "nixpkgsCross.android.arm64Impure has been deprecated, using nixpkgsCross.android.aarch64 instead." aarch64;
+        armv7aImpure = lib.warn "nixpkgsCross.android.armv7aImpure has been deprecated, using nixpkgsCross.android.aarch32 instead." aarch32;
       };
       ios =
         let config = {
@@ -132,7 +133,7 @@ let iosSupport =
                 };
               };
             };
-        in lib.mapAttrs (_: args: if args == null then null else nixpkgsFunc args) {
+        in lib.mapAttrs (_: args: if args == null then null else nixpkgsFunc args) rec {
         simulator64 = {
           system = "x86_64-darwin";
           overlays = globalOverlays ++ [appleLibiconvHack];
@@ -153,7 +154,7 @@ let iosSupport =
           };
           inherit config;
         };
-        arm64 = {
+        aarch64 = {
           system = "x86_64-darwin";
           overlays = globalOverlays ++ [appleLibiconvHack];
           crossSystem = {
@@ -173,6 +174,8 @@ let iosSupport =
           };
           inherit config;
         };
+        # Back compat
+        arm64 = lib.warn "nixpkgsCross.ios.arm64 has been deprecated, using nixpkgsCross.ios.aarch64 instead." aarch64;
       };
     };
     haskellLib = nixpkgs.haskell.lib;
@@ -459,7 +462,7 @@ let overrideCabal = pkg: f: if pkg == null then null else haskellLib.overrideCab
       haskellOverlays.ghc-7_8
     ];
   };
-  ghcAndroidArm64 = (makeRecursivelyOverridable nixpkgsCross.android.arm64Impure.pkgs.haskell.packages.ghc821).override {
+  ghcAndroidAarch64 = (makeRecursivelyOverridable nixpkgsCross.android.aarch64.pkgs.haskell.packages.ghc821).override {
     overrides = lib.foldr lib.composeExtensions (_: _: {}) [
       extendHaskellPackages
       (optionalExtension enableExposeAllUnfoldings haskellOverlays.exposeAllUnfoldings)
@@ -468,7 +471,7 @@ let overrideCabal = pkg: f: if pkg == null then null else haskellLib.overrideCab
       haskellOverlays.android
     ];
   };
-  ghcAndroidArmv7a = (makeRecursivelyOverridable nixpkgsCross.android.armv7aImpure.pkgs.haskell.packages.ghc821).override {
+  ghcAndroidAarch32 = (makeRecursivelyOverridable nixpkgsCross.android.armv7aImpure.pkgs.haskell.packages.ghc821).override {
     overrides = lib.foldr lib.composeExtensions (_: _: {}) [
       extendHaskellPackages
       (optionalExtension enableExposeAllUnfoldings haskellOverlays.exposeAllUnfoldings)
@@ -484,7 +487,7 @@ let overrideCabal = pkg: f: if pkg == null then null else haskellLib.overrideCab
       haskellOverlays.ghc-8_2_1
     ];
   };
-  ghcIosArm64 = (makeRecursivelyOverridable nixpkgsCross.ios.arm64.pkgs.haskell.packages.ghc821).override {
+  ghcIosAarch64 = (makeRecursivelyOverridable nixpkgsCross.ios.aarch64.pkgs.haskell.packages.ghc821).override {
     overrides = lib.foldr lib.composeExtensions (_: _: {}) [
       extendHaskellPackages
       (optionalExtension enableExposeAllUnfoldings haskellOverlays.exposeAllUnfoldings)
@@ -493,7 +496,7 @@ let overrideCabal = pkg: f: if pkg == null then null else haskellLib.overrideCab
       haskellOverlays.ios
     ];
   };
-  ghcIosArmv7 = (makeRecursivelyOverridable nixpkgsCross.ios.armv7.pkgs.haskell.packages.ghc821).override {
+  ghcIosAarch32 = (makeRecursivelyOverridable nixpkgsCross.ios.armv7.pkgs.haskell.packages.ghc821).override {
     overrides = lib.foldr lib.composeExtensions (_: _: {}) [
       extendHaskellPackages
       (optionalExtension enableExposeAllUnfoldings haskellOverlays.exposeAllUnfoldings)
@@ -502,12 +505,16 @@ let overrideCabal = pkg: f: if pkg == null then null else haskellLib.overrideCab
       haskellOverlays.ios
     ];
   };
+  # Back compat
+  ghcAndroidArm64 = lib.warn "ghcAndroidArm64 has been deprecated, using ghcAndroidAarch64 instead." ghcAndroidAarch64;
+  ghcAndroidArmv7a = lib.warn "ghcAndroidArmv7a has been deprecated, using ghcAndroidAarch32 instead." ghcAndroidAarch32;
+  ghcIosArm64 = lib.warn "ghcIosArm64 has been deprecated, using ghcIosAarch64 instead." ghcIosAarch64;
   #TODO: Separate debug and release APKs
   #TODO: Warn the user that the android app name can't include dashes
-  android = androidWithHaskellPackages { inherit ghcAndroidArm64 ghcAndroidArmv7a; };
-  androidWithHaskellPackages = { ghcAndroidArm64, ghcAndroidArmv7a }: import ./android {
+  android = androidWithHaskellPackages { inherit ghcAndroidAarch64 ghcAndroidAarch32; };
+  androidWithHaskellPackages = { ghcAndroidAarch64, ghcAndroidAarch32 }: import ./android {
     nixpkgs = nixpkgsFunc { system = "x86_64-linux"; };
-    inherit nixpkgsCross ghcAndroidArm64 ghcAndroidArmv7a overrideCabal;
+    inherit nixpkgsCross ghcAndroidAarch64 ghcAndroidAarch32 overrideCabal;
   };
 
   nix-darwin = fetchFromGitHub {
@@ -519,10 +526,10 @@ let overrideCabal = pkg: f: if pkg == null then null else haskellLib.overrideCab
   # TODO: This should probably be upstreamed to nixpkgs.
   plistLib = import (nix-darwin + /modules/launchd/lib.nix) { inherit lib; };
 
-  ios = iosWithHaskellPackages ghcIosArm64;
-  iosWithHaskellPackages = ghcIosArm64: {
+  ios = iosWithHaskellPackages ghcIosAarch64;
+  iosWithHaskellPackages = ghcIosAarch64: {
     buildApp = import ./ios {
-      inherit ghcIosArm64 plistLib;
+      inherit ghcIosAarch64 plistLib;
       nixpkgs = nixpkgsFunc { system = "x86_64-darwin"; };
     };
   };
@@ -541,16 +548,17 @@ in let this = rec {
           ghc7
           ghc7_8
           ghcIosSimulator64
-          ghcIosArm64
-          ghcIosArmv7
-          ghcAndroidArm64
-          ghcAndroidArmv7a
+          ghcIosAarch64
+          ghcIosAarch32
+          ghcAndroidAarch64
+          ghcAndroidAarch32
           ghcjs
           android
           androidWithHaskellPackages
           ios
           iosWithHaskellPackages
           filterGit;
+
   androidReflexTodomvc = android.buildApp {
     package = p: p.reflex-todomvc;
     executableName = "reflex-todomvc";
@@ -747,7 +755,8 @@ in let this = rec {
   } "";
 
   # The systems that we want to build for on the current system
-  cacheTargetSystems = [
+  cacheTargetSystems = lib.warn "cacheTargetSystems has been deprecated, use cacheBuildSystems" cacheBuildSystems;
+  cacheBuildSystems = [
     "x86_64-linux"
     "i686-linux"
     "x86_64-darwin"
@@ -767,9 +776,9 @@ in let this = rec {
 
   cachePackages =
     let otherPlatforms = optionals androidSupport [
-          "ghcAndroidArm64"
-          "ghcAndroidArmv7a"
-        ] ++ optional iosSupport "ghcIosArm64";
+          "ghcAndroidAarch64"
+          "ghcAndroidAarch32"
+        ] ++ optional iosSupport "ghcIosAarch64";
     in tryReflexPackages
       ++ builtins.map reflexEnv otherPlatforms
       ++ optionals androidSupport [

--- a/default.nix
+++ b/default.nix
@@ -59,7 +59,7 @@ let iosSupport =
     inherit (nixpkgs) lib fetchurl fetchgit fetchgitPrivate fetchFromGitHub;
     nixpkgsCross = {
       android = lib.mapAttrs (_: args: if args == null then null else nixpkgsFunc args) rec {
-        aarch64 = rec {
+        aarch64 = {
           system = "x86_64-linux";
           overlays = globalOverlays;
           crossSystem = {

--- a/default.nix
+++ b/default.nix
@@ -211,6 +211,10 @@ let overrideCabal = pkg: f: if pkg == null then null else haskellLib.overrideCab
     combineOverrides = old: new: old // new // optionalAttrs (old ? overrides && new ? overrides) {
       overrides = lib.composeExtensions old.overrides new.overrides;
     };
+    # Makes sure that old `overrides` from a previous call to `override` are not
+    # forgotten, but composed. Do this by overriding `override` and passing a
+    # function which takes the old argument set and combining it. What a tongue
+    # twister!
     makeRecursivelyOverridable = x: x // {
       override = new: makeRecursivelyOverridable (x.override (old: (combineOverrides old new)));
     };

--- a/default.nix
+++ b/default.nix
@@ -68,7 +68,7 @@ let iosSupport =
             libc = "bionic";
             withTLS = true;
             openssl.system = "linux-generic64";
-            platform = nixpkgs.pkgs.platforms.aarch64-multiplatform;
+            platform = lib.systems.examples.aarch64-multiplatform;
             useAndroidPrebuilt = true;
           };
           config.allowUnfree = true;
@@ -82,7 +82,7 @@ let iosSupport =
             libc = "bionic";
             withTLS = true;
             openssl.system = "linux-generic32";
-            platform = nixpkgs.pkgs.platforms.armv7l-hf-multiplatform;
+            platform = lib.systems.exmamples.armv7l-hf-multiplatform;
             useAndroidPrebuilt = true;
           };
           config.allowUnfree = true;

--- a/haskell-overlays/ghcjs.nix
+++ b/haskell-overlays/ghcjs.nix
@@ -1,5 +1,7 @@
 { haskellLib, nixpkgs, fetchFromGitHub, useReflexOptimizer }:
 
+let inherit (nixpkgs) lib; in
+
 self: super: {
   ghcWithPackages = selectFrom: self.callPackage (nixpkgs.path + "/pkgs/development/haskell-modules/with-packages-wrapper.nix") {
     inherit (self) llvmPackages;
@@ -24,6 +26,6 @@ self: super: {
   bytes = haskellLib.dontCheck super.bytes;
 
   # doctest doesn't work on ghcjs, but sometimes dontCheck doesn't seem to get rid of the dependency
-  doctest = builtins.trace "Warning: ignoring dependency on doctest" null;
+  doctest = lib.warn "ignoring dependency on doctest" null;
 
 }

--- a/ios/default.nix
+++ b/ios/default.nix
@@ -1,4 +1,4 @@
-{ nixpkgs, ghcIosArm64
+{ nixpkgs, ghcIosAarch64
 , plistLib # Set of functions for generating plist files from nix types
 }:
 
@@ -107,7 +107,7 @@ let
     '';
 in
 nixpkgs.runCommand "${executableName}-app" (rec {
-  exePath = package ghcIosArm64;
+  exePath = package ghcIosAarch64;
   infoPlist = builtins.toFile "Info.plist" (plistLib.toPLIST infoPlistData);
   resourceRulesPlist = builtins.toFile "ResourceRules.plist" (plistLib.toPLIST {
     rules = {

--- a/project/default.nix
+++ b/project/default.nix
@@ -177,16 +177,16 @@ let
     android =
       mapAttrs (name: config:
         let
-          ghcAndroidArm64 = this.ghcAndroidArm64.override { overrides = overrides'; };
-          ghcAndroidArmv7a = this.ghcAndroidArmv7a.override { overrides = overrides'; };
-        in (this.androidWithHaskellPackages { inherit ghcAndroidArm64 ghcAndroidArmv7a; }).buildApp
+          ghcAndroidAarch64 = this.ghcAndroidAarch64.override { overrides = overrides'; };
+          ghcAndroidAarch32 = this.ghcAndroidAarch32.override { overrides = overrides'; };
+        in (this.androidWithHaskellPackages { inherit ghcAndroidAarch64 ghcAndroidAarch32; }).buildApp
           ({ package = p: p.${name}; } // config)
       ) android;
 
     ios =
       mapAttrs (name: config:
-        let ghcIosArm64 = this.ghcIosArm64.override { overrides = overrides'; };
-        in (this.iosWithHaskellPackages ghcIosArm64).buildApp
+        let ghcIosAarch64 = this.ghcIosAarch64.override { overrides = overrides'; };
+        in (this.iosWithHaskellPackages ghcIosAarch64).buildApp
           ({ package = p: p.${name}; } // config)
       ) ios;
 

--- a/release.nix
+++ b/release.nix
@@ -20,6 +20,8 @@ in lib.genAttrs local-reflex-platform.cacheBuildSystems (system:
   in {
     tryReflexShell = reflex-platform.tryReflexShell;
     skeleton-test = import ./skeleton-test.nix { inherit reflex-platform; };
+  } // lib.optionalAttrs (system != "x86_64-darwin") {
+    # The node build is uncached and slow
     benchmark = import ./scripts/benchmark.nix { inherit reflex-platform; };
   } // lib.optionalAttrs (reflex-platform.androidSupport) {
     inherit (reflex-platform) androidReflexTodomvc;

--- a/release.nix
+++ b/release.nix
@@ -1,28 +1,28 @@
 {}:
 with import ./. {};
 let inherit (nixpkgs.lib) optionals;
-    getOtherDeps = reflexPlatform: [
-      reflexPlatform.stage2Script
-      reflexPlatform.nixpkgs.cabal2nix
-      reflexPlatform.ghc.cabal2nix
+    getOtherDeps = reflex-platform: [
+      reflex-platform.stage2Script
+      reflex-platform.nixpkgs.cabal2nix
+      reflex-platform.ghc.cabal2nix
     ] ++ builtins.concatLists (map
       (crossPkgs: optionals (crossPkgs != null) [
         crossPkgs.buildPackages.haskellPackages.cabal2nix
       ]) [
-        reflexPlatform.nixpkgsCross.ios.aarch64
-        reflexPlatform.nixpkgsCross.android.aarch64
-        reflexPlatform.nixpkgsCross.android.aarch32
+        reflex-platform.nixpkgsCross.ios.aarch64
+        reflex-platform.nixpkgsCross.android.aarch64
+        reflex-platform.nixpkgsCross.android.aarch32
       ]
     );
 
 in nixpkgs.lib.genAttrs cacheBuildSystems (system:
   let
-    reflexPlatform = (import ./. { inherit system; iosSupportForce = true; });
+    reflex-platform = (import ./. { inherit system; iosSupportForce = true; });
   in {
-    tryReflexShell = reflexPlatform.tryReflexShell;
-    skeleton-test = import ./skeleton-test.nix { this = reflexPlatform; };
+    tryReflexShell = reflex-platform.tryReflexShell;
+    skeleton-test = import ./skeleton-test.nix { this = reflex-platform; };
   } // nixpkgs.lib.listToAttrs
-    (builtins.map (drv: { inherit (drv) name; value = drv; }) (getOtherDeps reflexPlatform))
+    (builtins.map (drv: { inherit (drv) name; value = drv; }) (getOtherDeps reflex-platform))
 ) // {
   benchmark = import ./scripts/benchmark.nix {};
   inherit sources iosReflexTodomvc androidReflexTodomvc;

--- a/release.nix
+++ b/release.nix
@@ -20,7 +20,7 @@ in nixpkgs.lib.genAttrs cacheBuildSystems (system:
     reflex-platform = (import ./. { inherit system; iosSupportForce = true; });
   in {
     tryReflexShell = reflex-platform.tryReflexShell;
-    skeleton-test = import ./skeleton-test.nix { this = reflex-platform; };
+    skeleton-test = import ./skeleton-test.nix { inherit reflex-platform; };
   } // nixpkgs.lib.listToAttrs
     (builtins.map (drv: { inherit (drv) name; value = drv; }) (getOtherDeps reflex-platform))
 ) // {

--- a/release.nix
+++ b/release.nix
@@ -1,6 +1,5 @@
-{}:
-with import ./. {};
-let inherit (nixpkgs) lib;
+let local-reflex-platform = import ./. {};
+    inherit (local-reflex-platform.nixpkgs) lib;
     getOtherDeps = reflex-platform: [
       reflex-platform.stage2Script
       reflex-platform.nixpkgs.cabal2nix
@@ -15,15 +14,17 @@ let inherit (nixpkgs) lib;
       ]
     );
 
-in lib.genAttrs cacheBuildSystems (system:
+in lib.genAttrs local-reflex-platform.cacheBuildSystems (system:
   let
-    reflex-platform = (import ./. { inherit system; iosSupportForce = true; });
+    reflex-platform = (import ./. { inherit system; iosSupportForce = system == "x86_64-darwin"; });
   in {
     tryReflexShell = reflex-platform.tryReflexShell;
     skeleton-test = import ./skeleton-test.nix { inherit reflex-platform; };
+    benchmark = import ./scripts/benchmark.nix { inherit reflex-platform; };
+  } // lib.optionalAttrs (reflex-platform.androidSupport) {
+    inherit (reflex-platform) androidReflexTodomvc;
+  } // lib.optionalAttrs (reflex-platform.iosSupport) {
+    inherit (reflex-platform) iosReflexTodomvc;
   } // lib.listToAttrs
     (builtins.map (drv: { inherit (drv) name; value = drv; }) (getOtherDeps reflex-platform))
-) // {
-  benchmark = import ./scripts/benchmark.nix {};
-  inherit sources iosReflexTodomvc androidReflexTodomvc;
-}
+  )

--- a/release.nix
+++ b/release.nix
@@ -1,12 +1,12 @@
 {}:
 with import ./. {};
-let inherit (nixpkgs.lib) optionals;
+let inherit (nixpkgs) lib;
     getOtherDeps = reflex-platform: [
       reflex-platform.stage2Script
       reflex-platform.nixpkgs.cabal2nix
       reflex-platform.ghc.cabal2nix
     ] ++ builtins.concatLists (map
-      (crossPkgs: optionals (crossPkgs != null) [
+      (crossPkgs: lib.optionals (crossPkgs != null) [
         crossPkgs.buildPackages.haskellPackages.cabal2nix
       ]) [
         reflex-platform.nixpkgsCross.ios.aarch64
@@ -15,13 +15,13 @@ let inherit (nixpkgs.lib) optionals;
       ]
     );
 
-in nixpkgs.lib.genAttrs cacheBuildSystems (system:
+in lib.genAttrs cacheBuildSystems (system:
   let
     reflex-platform = (import ./. { inherit system; iosSupportForce = true; });
   in {
     tryReflexShell = reflex-platform.tryReflexShell;
     skeleton-test = import ./skeleton-test.nix { inherit reflex-platform; };
-  } // nixpkgs.lib.listToAttrs
+  } // lib.listToAttrs
     (builtins.map (drv: { inherit (drv) name; value = drv; }) (getOtherDeps reflex-platform))
 ) // {
   benchmark = import ./scripts/benchmark.nix {};

--- a/release.nix
+++ b/release.nix
@@ -9,13 +9,13 @@ let inherit (nixpkgs.lib) optionals;
       (crossPkgs: optionals (crossPkgs != null) [
         crossPkgs.buildPackages.haskellPackages.cabal2nix
       ]) [
-        reflexPlatform.nixpkgsCross.ios.arm64
-        reflexPlatform.nixpkgsCross.android.arm64Impure
-        reflexPlatform.nixpkgsCross.android.armv7aImpure
+        reflexPlatform.nixpkgsCross.ios.aarch64
+        reflexPlatform.nixpkgsCross.android.aarch64
+        reflexPlatform.nixpkgsCross.android.aarch32
       ]
     );
 
-in nixpkgs.lib.genAttrs cacheTargetSystems (system:
+in nixpkgs.lib.genAttrs cacheBuildSystems (system:
   let
     reflexPlatform = (import ./. { inherit system; iosSupportForce = true; });
   in {

--- a/release.nix
+++ b/release.nix
@@ -20,7 +20,7 @@ in lib.genAttrs local-reflex-platform.cacheBuildSystems (system:
   in {
     tryReflexShell = reflex-platform.tryReflexShell;
     skeleton-test = import ./skeleton-test.nix { inherit reflex-platform; };
-  } // lib.optionalAttrs (system != "x86_64-darwin") {
+  } // lib.optionalAttrs (system == "x86_64-linux") {
     # The node build is uncached and slow
     benchmark = import ./scripts/benchmark.nix { inherit reflex-platform; };
   } // lib.optionalAttrs (reflex-platform.androidSupport) {

--- a/scripts/cache.nix
+++ b/scripts/cache.nix
@@ -2,7 +2,7 @@ with import ./.. {};
 let inherit (nixpkgs.lib) optionals;
     inputs = builtins.concatLists [
       (builtins.attrValues sources)
-      (map (system: (import ./.. { inherit system; iosSupportForce = true; }).cachePackages) cacheTargetSystems)
+      (map (system: (import ./.. { inherit system; iosSupportForce = true; }).cachePackages) cacheBuildSystems)
     ];
     getOtherDeps = reflexPlatform: [
       reflexPlatform.stage2Script
@@ -11,12 +11,12 @@ let inherit (nixpkgs.lib) optionals;
       (crossPkgs: optionals (crossPkgs != null) [
         crossPkgs.buildPackages.haskellPackages.cabal2nix
       ]) [
-        reflexPlatform.nixpkgsCross.ios.arm64
-        reflexPlatform.nixpkgsCross.android.arm64Impure
-        reflexPlatform.nixpkgsCross.android.armv7aImpure
+        reflexPlatform.nixpkgsCross.ios.aarch64
+        reflexPlatform.nixpkgsCross.android.aarch64
+        reflexPlatform.nixpkgsCross.android.aarch32
       ]
     );
     otherDeps = builtins.concatLists (
-      map (system: getOtherDeps (import ./.. { inherit system; })) cacheTargetSystems
+      map (system: getOtherDeps (import ./.. { inherit system; })) cacheBuildSystems
     ) ++ [(import ./benchmark.nix {})];
 in pinBuildInputs "reflex-platform" inputs otherDeps

--- a/scripts/ios-deploy-todomvc.sh
+++ b/scripts/ios-deploy-todomvc.sh
@@ -32,7 +32,7 @@ if [ -z "$signer" ]; then
 fi
 
 mkdir -p $tmpdir/reflex-todomvc.app
-cp -r `nix-build --no-out-link -A ghcIosArm64.reflex-todomvc`/reflex-todomvc.app/* $tmpdir/reflex-todomvc.app
-sed "s|<team-id/>|$1|" < "$(eval "echo $(nix-instantiate --eval -E '(import ./. {}).ghcIosArm64.reflex-todomvc.src')")/reflex-todomvc.app.xcent" > $tmpdir/reflex-todomvc.app.xcent
+cp -r `nix-build --no-out-link -A ghcIosAarch64.reflex-todomvc`/reflex-todomvc.app/* $tmpdir/reflex-todomvc.app
+sed "s|<team-id/>|$1|" < "$(eval "echo $(nix-instantiate --eval -E '(import ./. {}).ghcIosAarch64.reflex-todomvc.src')")/reflex-todomvc.app.xcent" > $tmpdir/reflex-todomvc.app.xcent
 /usr/bin/codesign --force --sign "$signer" --entitlements $tmpdir/reflex-todomvc.app.xcent --timestamp=none $tmpdir/reflex-todomvc.app
 "$(nix-build --no-out-link -A nixpkgs.nodePackages.ios-deploy)/bin/ios-deploy" -W -b $tmpdir/reflex-todomvc.app

--- a/skeleton-test.nix
+++ b/skeleton-test.nix
@@ -1,7 +1,7 @@
-{ this }:
+{ reflex-platform }:
 
 let
-  skeletonSrc = this.nixpkgs.fetchFromGitHub {
+  skeletonSrc = reflex-platform.nixpkgs.fetchFromGitHub {
     owner = "ElvishJerricco";
     repo = "reflex-project-skeleton";
     rev = "d1cf6b26a9aa08b192e3e81ae07a4ba00064d6d2";
@@ -9,7 +9,7 @@ let
     fetchSubmodules = false; # Not interested in its reflex-platform checkout
   };
 
-  skeleton = import skeletonSrc { reflex-platform = this; };
+  skeleton = import skeletonSrc { inherit reflex-platform; };
 
   mkCabalProject = { shellDrv, projectFile }: shellDrv.overrideAttrs (old: {
     name = "reflex-project-skeleton-${projectFile}";


### PR DESCRIPTION
This is done to reduce merge conflicts make for an actually auditable final merge. Whenever public-facing names are changed, an alias with a deprecation warning should be provided.