### PR TITLE
android: Fix deploy script

### DIFF
--- a/android/impl.nix
+++ b/android/impl.nix
@@ -11,7 +11,8 @@ let overrideAndroidCabal = package: overrideCabal package (drv: {
         mkdir -p "$out/bin"
         cp -r "$src"/* "$out"
         cat >"$out/bin/deploy" <<EOF
-          $(which adb) install -r "$(echo $out/*.apk)"
+        #!/usr/bin/env bash
+        $(command -v adb) install -r "$(echo $out/*.apk)"
         EOF
         chmod +x "$out/bin/deploy"
       '';


### PR DESCRIPTION
Fixes 
```
exec: Exec format error
The file '/nix/store/kp6hyqi1fl33yf34rpvjgq4vxvmg788i-android-app/bin/deploy' is marked as an executable but could not be run by the operating system.
```