### PR TITLE
Stop nulling out some packages for GHCJS

### DIFF
--- a/haskell-overlays/ghcjs.nix
+++ b/haskell-overlays/ghcjs.nix
@@ -17,10 +17,6 @@ self: super: {
     withPackages = self.ghcWithPackages;
   };
 
-  hlint = null;
-  hscolour = null;
-  cabal-macosx = null;
-
   # doctest doesn't work on ghcjs, but sometimes dontCheck doesn't seem to get rid of the dependency
   doctest = lib.warn "ignoring dependency on doctest" null;
 

--- a/reflex-todomvc/github.json
+++ b/reflex-todomvc/github.json
@@ -1,6 +1,6 @@
 {
   "owner": "reflex-frp",
   "repo": "reflex-todomvc",
-  "rev": "27fcfe1d5e6aab1ce9c6b9369a5af7ee84e69bde",
-  "sha256": "0zikp2zafd2dpz7vr7vpdylgq7b1rsa0hx4rcnlzlig43frfjvma"
+  "rev": "b460a2049b2df2b087a98ee81a6c03fd791983de",
+  "sha256": "16kgayi2q0kl60322ilgmdka6hawkjkks0x9gd1ji2nr2vnramp0"
 }


### PR DESCRIPTION
This was done because they kept on trying to be built for Setup.hs. That problem is fixed properly now, so it should be safe to remove these.

Additionally, hscolour is also a library that could be used by a GHCJS app. By making this libary availible, this cleanup provides a practical benefit. Semantic-reflex-example in particular uses hscolour as a library.