### PR TITLE
nixpkgs/default.nix: use builtins.fetchTarball

### DIFF
--- a/nixpkgs/default.nix
+++ b/nixpkgs/default.nix
@@ -1,1 +1,8 @@
-import ((import <nixpkgs> {}).fetchFromGitHub (builtins.fromJSON (builtins.readFile ./github.json)))
+let
+  fetchFromGitHub = if (builtins ? "fetchTarball")
+    then { owner, repo, rev, sha256 }: builtins.fetchTarball {
+        inherit sha256;
+        url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz";
+      }
+    else (import <nixpkgs> {}).fetchFromGitHub;
+in import (fetchFromGitHub (builtins.fromJSON (builtins.readFile ./github.json)))


### PR DESCRIPTION
There's no longer any reason to use `fetchFromGitHub` to bootstrap `nixpkgs` from Nix 2.0 onwards.