### PR TITLE
Rewrite hacking documentation to be clearer in examples

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -1,19 +1,51 @@
-Hacking on the Reflex Platform
-==============================
+# Hacking on the Reflex Platform
 
-To work on a particular package, use the work-on script **instead of** `./try-reflex`:
+This guide shows you how to use Reflex Platform in your own projects.
+Reflex Platform contains a number of useful scripts that make this
+process easier for you.
+
+## Working on packages (the work-on script)
+
+To work on a particular package, use the work-on script **instead of**
+`./try-reflex`:
 
 ```
 ~/reflex-platform/scripts/work-on ghcjs ./your-project
 ```
 
-This will use your package's cabal file to determine dependencies.  If you have a default.nix, it will use that instead.  Note that your project's path must include at least one slash ('/') so that work-on can detect that it is a path, rather than a package name.
+This will use your package's cabal file to determine dependencies. If
+you have a default.nix, it will use that instead. Note that your
+project's path must include at least one slash ('/') so that work-on
+can detect that it is a path, rather than a package name.
 
-This will give you the exact environment needed to work with the given package and platform, rather than the general-purpose environment provided by the Reflex Platform.
+This will give you the exact environment needed to work with the given
+package and platform, rather than the general-purpose environment
+provided by the Reflex Platform. Once inside the resulting shell,
+you'll have access to the environment in which the package is built
+with a few more tools (such as cabal-install) added.
 
-You can replace `ghcjs` with `ghc` to hack on the native GHC version of the package (including with GHCi if you want).  You can also use a package name instead of a path, which will drop you into the standard build environment of that package; this works even if you don't yet have the source for that package.
+### Custom values for “platform”
 
-Instead of specifying `ghcjs` or `ghc` for the platform, you can also specify a path to a nix expression file whose value represents a Haskell environment, for example:
+The first argument of work-on corresponds to the Haskell platform.
+Many different platform are provided for you. A partial list of
+possible platforms include:
+
+- ghc
+- ghcHEAD
+- ghc8_4
+- ghc8_2
+- ghc8_0
+- ghc7
+- ghcjs
+- ghcjs8_0
+- ghcjs8_2
+- ghcjs8_4
+
+In addition, instead of specifying the name of the platform, you can
+specify a path to a Nix expression file representing a Haskell
+environment.
+
+For example, you can create a file called env.nix like so:
 
 ```
 { reflex-platform, ... }: reflex-platform.ghcjs.override {
@@ -23,35 +55,64 @@ Instead of specifying `ghcjs` or `ghc` for the platform, you can also specify a 
 }
 ```
 
-Finally, you can specify a parenthesized expression as your platform, which will be interpreted as a raw nix expression.  For example, `(import ./my-platform.nix {})`.
-
-Once inside the shell, you'll have access to the environment in which the package is built with a few more tools (such as cabal-install) added.
-
-Checking out a sub-repo
------------------------
-
-The `hack-on` script is provided for conveniently checking out a sub-repository.
+You can now run work-on with this new platform like so:
 
 ```
-./scripts/hack-on dep/reflex
+~/reflex-platform/scripts/work-on ./env.nix ./your-project
 ```
 
-This will check out the same version of `reflex` currently being used by the Reflex Platform.  Note that `dep/reflex`, here, is a path relative to the current directory, so you must be in this folder when you execute this.
+Finally, you can specify a parenthesized expression as your platform,
+which will be interpreted as a raw nix expression. For example,
+`(import ./my-platform.nix {})`.
 
-Once the repository is checked out, you can make modifications to it, which will be used the next time you enter a try-reflex or work-on shell.  Existing sessions will not be affected—exit and re-enter your shell to use the changes.
+### Custom values for “package”
 
-When you have completed some work hacking on the sub-repository, you can use the `hack-add` script to check your changes into this repository without needing to delete the repository, like so:
+The second argument of work-on corresponds to the Haskell package.
+This is meant to be the package that you are wanting to work on.
+
+Package can be a name of a package. In this case, the name will be
+looked up in the Hackage database.
+
+Otherwise, this should be a path to the package. Any directory with a
+.cabal file should work. In addition, this script will use a .nix file
+for the package if it exists.
+
+## Checking out a sub-repo (the hack-on script)
+
+The `hack-on` script is provided for conveniently checking out a
+sub-repository.
 
 ```
-./scripts/hack-add dep/reflex
+~/reflex-platform/scripts/hack-on dep/reflex
 ```
 
-You can then commit and push reflex-platform without needing to delete the sub-repository.
+This will check out the same version of `reflex` currently being used
+by the Reflex Platform. Note that `dep/reflex`, here, is a path
+relative to the current directory, so you must be in this folder when
+you execute this.
 
-When you are completely done with a sub-repository, you can remove it using `hack-off`:
+Once the repository is checked out, you can make modifications to it,
+which will be used the next time you enter a try-reflex or work-on
+shell. Existing sessions will not be affected—exit and re-enter your
+shell to use the changes.
+
+When you have completed some work hacking on the sub-repository, you
+can use the `hack-add` script to check your changes into this
+repository without needing to delete the repository, like so:
 
 ```
-./scripts/hack-off dep/reflex
+~/reflex-platform/scripts/hack-add dep/reflex
 ```
 
-This will remove the repository and replace the `default.nix` and `git.json` files that were pointing to it before running `hack-on`.
+You can then commit and push reflex-platform without needing to delete
+the sub-repository.
+
+When you are completely done with a sub-repository, you can remove it
+using `hack-off`:
+
+```
+~/reflex-platform/scripts/hack-off dep/reflex
+```
+
+This will remove the repository and replace the `default.nix` and
+`git.json` files that were pointing to it before running `hack-on`.


### PR DESCRIPTION
This documentation was a little confusing. This makes it more clear
what values are expected to the work-on script.

In #80, an error occurred when you passed the example Nix expression as the second argument instead of the first. This tries to resolve that by making it clear which example goes in which place.

Fixes #80.