### PR TITLE
Prioritize *.cabal over default.nix for work-on

### DIFF
--- a/scripts/common-setup.sh
+++ b/scripts/common-setup.sh
@@ -267,10 +267,12 @@ package_invocation() {
     if echo "$PACKAGE" | grep -q / ; then
         # Package name includes a slash
         local PACKAGE_PATH="$(cleanup_nix_path "$PACKAGE")"
-        if ( echo "$PACKAGE_PATH" | grep -q '\.nix$' && [ -f "$PACKAGE_PATH" ] ) || [ -f "$PACKAGE_PATH/default.nix" ] ; then
+        if ( echo "$PACKAGE_PATH" | grep -q '\.nix$' && [ -f "$PACKAGE_PATH" ] ); then
             echo -n "($EFFECTIVE_PLATFORM.callPackage $PACKAGE_PATH {})"
         elif test -n "$(shopt -s nullglob ; echo "$PACKAGE_PATH"/*.cabal)" ; then
             echo -n "($EFFECTIVE_PLATFORM.callCabal2nix \"$(basename "$PACKAGE_PATH"/*.cabal | sed 's/\.cabal$//')\" $PACKAGE_PATH {})"
+        elif [ -f "$PACKAGE_PATH/default.nix" ] ; then
+            echo -n "($EFFECTIVE_PLATFORM.callPackage $PACKAGE_PATH {})"
         else
             user_error 1 "Error: The given path must be a nix expression, a directory with a default.nix, or a directory with a cabal file"
         fi


### PR DESCRIPTION
The work-on script uses package_invocation to find a package. This
will default to finding the default.nix script. Some users like in
 #101 don’t want work-on to pick up the default.nix script as they are
using default.nix for other reasons. To fix this, we can just
prioritize Cabal over default.nix. The scripts will still look in
default.nix if there are no cabal files available. Because cabal2nix
has gotten pretty good, it is a pretty safe idea in this case.

Fixes #101