### PR TITLE
Pass --enable-dynamic-executable on macOS

### DIFF
--- a/haskell-overlays/default.nix
+++ b/haskell-overlays/default.nix
@@ -134,6 +134,7 @@ rec {
     inherit haskellLib;
     inherit fetchFromGitHub;
     inherit enableLibraryProfiling;
+    inherit nixpkgs;
   };
 
   hie = import ./hie {

--- a/haskell-overlays/untriaged.nix
+++ b/haskell-overlays/untriaged.nix
@@ -1,6 +1,7 @@
 { haskellLib
 , fetchFromGitHub
 , enableLibraryProfiling
+, nixpkgs
 }:
 
 with haskellLib;
@@ -47,5 +48,10 @@ self: super: {
 
   mkDerivation = expr: super.mkDerivation (expr // {
     inherit enableLibraryProfiling;
+    enableSharedExecutables = expr.enableSharedExecutables or nixpkgs.stdenv.isDarwin;
+  });
+
+  cabal2nix = overrideCabal super.cabal2nix (_: {
+    enableSharedExecutables = false;
   });
 }


### PR DESCRIPTION
This is needed for cabal to add the rpaths correctly. Basically, these two settings are conflicting:

- https://github.com/obsidiansystems/obelisk/blob/develop/skeleton/frontend/frontend.cabal#L32
- https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/haskell-modules/generic-builder.nix#L32 

and we need to override it on macOS.