### PR TITLE
Update README examples so they compile without warnings

### DIFF
--- a/examples/host.hs
+++ b/examples/host.hs
@@ -7,7 +7,7 @@ This program gives an example of how to construct a simple framework that
 allows programmers to write FRP applications that process keystrokes (of
 type Char) to produce a view (of type String).  This model, where programmers
 process Event(s) to produce Behavior(s) is akin to the OpenGL/GLUT model, where
-input is pushed into the application via callbacks and and output is pulled
+input is pushed into the application via callbacks and an output is pulled
 via periodic sampling in a render function.  Other application models work
 differently; for example, DOM applications built with reflex-dom ultimately
 produce Events rather than Behaviors as their output, since changes need to be
@@ -56,7 +56,7 @@ host myGuest =
   runSpiderHost $ do
 
     -- Create an event to be used as input.
-    -- It will fire wehenver we use eTriggerRef.
+    -- It will fire whenever we use eTriggerRef.
     (e, eTriggerRef) <- newEventWithTriggerRef
 
     -- Evaluate our user's program to set up the data flow graph.


### PR DESCRIPTION
As I was going through all the examples in the README, there was an annoying warning when compiling the examples from try-reflex environment:

```
reflex-platform]$ ghcjs main.lhs 
[1 of 1] Compiling Main             ( main.lhs, main.js_o )

main.lhs:13:18: warning: [-Wsimplifiable-class-constraints]
    • The constraint ‘MonadWidget t m’ matches an instance declaration
      instance Reflex.Dom.Old.MonadWidgetConstraints t m =>
               MonadWidget t m
        -- Defined in ‘Reflex.Dom.Old’
      This makes type inference for inner bindings fragile;
        either use MonoLocalBinds, or simplify it using the instance
    • In the type signature:
        numberInput :: MonadWidget t m => m (Dynamic t (Maybe Double))
   |
13 | > numberInput :: MonadWidget t m => m (Dynamic t (Maybe Double))
   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

I updated all the type signatures in the readme examples to use the (supposedly the latest) type type class DomBuilder to avoid those warnings.o I checked that my changes work and allow compilation without warnings.

Additionally I did minor changes in the markdown, as some markdown tooling can't parse headers (starting with couple of '#'s) unless they start at the beginning of the line. For example see diffs in this PR which highlights the headings when they start with # as the first character on the line.