### PR TITLE
clean top level: Move `cacheBuildSystems` into release.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -500,14 +500,6 @@ in let this = rec {
     inherit buildInputs otherDeps;
   });
 
-  # The systems that we want to build for on the current system
-  cacheTargetSystems = lib.warn "cacheTargetSystems has been deprecated, use cacheBuildSystems" cacheBuildSystems;
-  cacheBuildSystems = [
-    "x86_64-linux"
-    # "i686-linux"
-    "x86_64-darwin"
-  ];
-
   isSuffixOf = suffix: s:
     let suffixLen = builtins.stringLength suffix;
     in builtins.substring (builtins.stringLength s - suffixLen) suffixLen s == suffix;

--- a/release.nix
+++ b/release.nix
@@ -20,7 +20,13 @@ let
   drvListToAttrs = drvs:
     lib.listToAttrs (map (drv: { inherit (drv) name; value = drv; }) drvs);
 
-  perPlatform = lib.genAttrs local-self.cacheBuildSystems (system: let
+  cacheBuildSystems = [
+    "x86_64-linux"
+    # "i686-linux"
+    "x86_64-darwin"
+  ];
+
+  perPlatform = lib.genAttrs cacheBuildSystems (system: let
     getRP = args: import ./. ((self-args // { inherit system; }) // args);
     reflex-platform = getRP {};
     reflex-platform-profiled = getRP { enableLibraryProfiling = true; };


### PR DESCRIPTION
From https://github.com/reflex-frp/reflex-platform/pull/482