### PR TITLE
clean top level: Remove unused `isSuffixOf`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -508,10 +508,6 @@ in let this = rec {
     "x86_64-darwin"
   ];
 
-  isSuffixOf = suffix: s:
-    let suffixLen = builtins.stringLength suffix;
-    in builtins.substring (builtins.stringLength s - suffixLen) suffixLen s == suffix;
-
   reflexEnv = platform:
     let haskellPackages = builtins.getAttr platform this;
         ghcWithStuff = if platform == "ghc" || platform == "ghcjs"


### PR DESCRIPTION
From #482