### PR TITLE
clean top level: Remove `otherInputs` argument from `pinBuildInputs`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -490,14 +490,14 @@ in let this = rec {
   # A simple derivation that just creates a file with the names of all
   # of its inputs. If built, it will have a runtime dependency on all
   # of the given build inputs.
-  pinBuildInputs = name: buildInputs: otherDeps: (nixpkgs.releaseTools.aggregate {
+  pinBuildInputs = name: buildInputs: (nixpkgs.releaseTools.aggregate {
     inherit name;
-    constituents = buildInputs ++ otherDeps;
+    constituents = buildInputs;
   }).overrideAttrs (old: {
     buildCommand = old.buildCommand + ''
-      echo "$propagatedBuildInputs $buildInputs $nativeBuildInputs $propagatedNativeBuildInputs $otherDeps" > "$out/deps"
+      echo "$propagatedBuildInputs $buildInputs $nativeBuildInputs $propagatedNativeBuildInputs" > "$out/deps"
     '';
-    inherit buildInputs otherDeps;
+    inherit buildInputs;
   });
 
   # The systems that we want to build for on the current system
@@ -552,6 +552,6 @@ in let this = rec {
 
   inherit cabal2nixResult system androidSupport iosSupport;
   project = args: import ./project this (args ({ pkgs = nixpkgs; } // this));
-  tryReflexShell = pinBuildInputs ("shell-" + system) tryReflexPackages [];
+  tryReflexShell = pinBuildInputs ("shell-" + system) tryReflexPackages;
   ghcjsExternsJs = ./ghcjs.externs.js;
 }; in this

--- a/release.nix
+++ b/release.nix
@@ -67,8 +67,7 @@ let
     skeleton-test-ghcjs = skeleton-test.ghcjs;
     inherit benchmark;
     cache = reflex-platform.pinBuildInputs "reflex-platform-${system}"
-      (builtins.attrValues dep ++ reflex-platform.cachePackages)
-      otherDeps;
+      (builtins.attrValues dep ++ reflex-platform.cachePackages ++ otherDeps);
   } // lib.optionalAttrs (reflex-platform.androidSupport) {
     inherit (reflex-platform) androidReflexTodomvc;
     inherit (reflex-platform) androidReflexTodomvc-8_6;
@@ -81,9 +80,7 @@ let
     // drvListToAttrs (lib.filter lib.isDerivation reflex-platform.cachePackages) # TODO no filter
   );
 
-  metaCache = local-self.pinBuildInputs
-    "reflex-platform-everywhere"
-    (map (a: a.cache) (builtins.attrValues perPlatform))
-    [];
+  metaCache = local-self.pinBuildInputs "reflex-platform-everywhere"
+    (map (a: a.cache) (builtins.attrValues perPlatform));
 
 in perPlatform // { inherit metaCache; }


### PR DESCRIPTION
This was to hack around a stage 2 script issue that is now fixed.

From #482