### PR TITLE
Patch network for GHCJS

### DIFF
--- a/haskell-overlays/ghcjs-network.patch
+++ b/haskell-overlays/ghcjs-network.patch
@@ -1,0 +1,16 @@
+diff --git a/Network/Socket.hsc b/Network/Socket.hsc
+index 4edebd4..43ecdb7 100644
+--- a/Network/Socket.hsc
++++ b/Network/Socket.hsc
+@@ -479,11 +479,7 @@ setNonBlockIfNeeded fd =
+ --
+ --   Since 2.7.0.0.
+ setCloseOnExecIfNeeded :: CInt -> IO ()
+-#if defined(mingw32_HOST_OS)
+ setCloseOnExecIfNeeded _ = return ()
+-#else
+-setCloseOnExecIfNeeded fd = System.Posix.Internals.setCloseOnExec fd
+-#endif
+ 
+ #if !defined(mingw32_HOST_OS)
+ foreign import ccall unsafe "fcntl"

--- a/haskell-overlays/ghcjs.nix
+++ b/haskell-overlays/ghcjs.nix
@@ -30,6 +30,12 @@ self: super: {
   # doctest doesn't work on ghcjs, but sometimes dontCheck doesn't seem to get rid of the dependency
   doctest = lib.warn "ignoring dependency on doctest" null;
 
+  network = haskellLib.overrideCabal super.network (drv: {
+    revision = null;
+    editedCabalFile = null;
+    patches = (drv.patches or []) ++ [ ./ghcjs-network.patch ];
+  });
+
   # These packages require doctest
   comonad = dontCheck super.comonad;
   http-types = dontCheck super.http-types;


### PR DESCRIPTION
I'm not sure why adding `|| defined(ghcjs_HOST_OS)` wasn't working, so I ended up just nuking the CPP entirely, expecting this to only be applied on GHCJS anyway