### PR TITLE
Bump Nixpkgs for callCabal2nix to work better on android

### DIFF
--- a/haskell-overlays/hie/default.nix
+++ b/haskell-overlays/hie/default.nix
@@ -29,4 +29,5 @@ in self: super: {
   haskell-lsp-types = self.callHackage "haskell-lsp-types" "0.15.0.0" {};
   rope-utf16-splay = self.callHackage "rope-utf16-splay" "0.3.1.0" {};
   unix-time = self.callHackage "unix-time" "0.4.7" {};
+  fold-debounce = (if nixpkgs.hostPlatform.isDarwin then dontCheck else (x: x)) super.fold-debounce;
 }

--- a/nixpkgs/default.nix
+++ b/nixpkgs/default.nix
@@ -1,8 +1,9 @@
 let
-  fetchFromGitHub = if (builtins ? "fetchTarball")
-    then { owner, repo, rev, sha256 }: builtins.fetchTarball {
+  fetchFromGitHub = { owner, repo, rev, sha256, branch }:
+    if (builtins ? "fetchTarball")
+    then builtins.fetchTarball {
         inherit sha256;
         url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz";
       }
-    else (import <nixpkgs> {}).fetchFromGitHub;
+    else (import <nixpkgs> {}).fetchFromGitHub { inherit owner repo rev; };
 in import (fetchFromGitHub (builtins.fromJSON (builtins.readFile ./github.json)))

--- a/nixpkgs/github.json
+++ b/nixpkgs/github.json
@@ -1,6 +1,7 @@
 {
   "owner": "nixos",
   "repo": "nixpkgs-channels",
-  "rev": "754763ff4ba1dd03fe3fad3a0fea36d2e39f5860",
-  "sha256": "10752kda1rzljlpcchi826hmbc8853vnbg9rkh7s89mxq6yjnm15"
+  "branch": "nixos-19.03",
+  "rev": "9d55c1430af72ace3a479d5e0a90451108e774b4",
+  "sha256": "05625fwgsa15i2jlsf2ymv3jx68362nf3zqbpnrwq6d3sn89liny"
 }


### PR DESCRIPTION
When `hydra.nixos.org` catches back up, we can make it `nixpkgs-channels` again