### PR TITLE
Only include /bin of build tools

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,9 @@ This project's release branch is `master`. This log is written from the perspect
 * Update to the nixos-19.03 nixpkgs channel
 * Update to gradle build tools 3.1.0, androidsdk 9, and default to android platform version 28
 * Bump reflex-dom 0.5.2
+* Fixes an inconsistency between nix-shell and nix-build where certain
+  Haskell build tools were not being overriden
+  ([#548](https://github.com/reflex-frp/reflex-platform/pull/548)
 
 ## v0.1.0.0 - 2019-04-03
 

--- a/default.nix
+++ b/default.nix
@@ -472,16 +472,19 @@ in let this = rec {
         })).out;
         notInTargetPackageSet = p: all (pname: (p.pname or "") != pname) packageNames;
         baseTools = generalDevToolsAttrs env;
-        overriddenTools = attrValues (baseTools // shellToolOverrides env baseTools);
+        overriddenTools = baseTools // shellToolOverrides env baseTools;
         depAttrs = lib.mapAttrs (_: v: filter notInTargetPackageSet v) (concatCombinableAttrs (concatLists [
           (map getHaskellConfig (lib.attrVals packageNames env))
           [{
-            buildTools = [(nixpkgs.buildEnv {
-              name = "build-tools-wrapper";
-              paths = overriddenTools ++ tools env;
-              pathsToLink = [ "/bin" ];
-              extraOutputsToInstall = [ "bin" ];
-            })];
+            buildTools = [
+              (nixpkgs.buildEnv {
+                name = "build-tools-wrapper";
+                paths = attrValues overriddenTools ++ tools env;
+                pathsToLink = [ "/bin" ];
+                extraOutputsToInstall = [ "bin" ];
+              })
+              overriddenTools.Cabal
+            ];
           }]
         ]));
 

--- a/default.nix
+++ b/default.nix
@@ -476,7 +476,12 @@ in let this = rec {
         depAttrs = lib.mapAttrs (_: v: filter notInTargetPackageSet v) (concatCombinableAttrs (concatLists [
           (map getHaskellConfig (lib.attrVals packageNames env))
           [{
-            buildTools = overriddenTools ++ tools env;
+            buildTools = [(nixpkgs.buildEnv {
+              name = "build-tools-wrapper";
+              paths = overriddenTools ++ tools env;
+              pathsToLink = [ "/bin" ];
+              extraOutputsToInstall = [ "bin" ];
+            })];
           }]
         ]));
 


### PR DESCRIPTION
Some of our build tools like ghcid are themselves Haskell packages. As
a result, their propagated dependencies would wind up in the
package.conf.d when strictDeps = false. This leads to an inconsistency
between “ob run” which uses these build tools and everything else. To
avoid exposing the entire build tools package, we wrap each so that
only /bin/* is available in the shell.