### PR TITLE
Fix GHC 8.6.5 segfault due to ghc#16893

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,9 @@ This project's release branch is `master`. This log is written from the perspect
 
 * Document how to accept android sdk license agreement and pass acceptance through to android infrastructure.
 * Update to GHC(JS) 8.6.5
+  * Apply workaround patch for
+    [ghc#16893](https://gitlab.haskell.org/ghc/ghc/issues/16893),
+    avoiding segmentation fault when using base.
 * Update to the nixos-19.03 nixpkgs channel
 * Update to gradle build tools 3.1.0, androidsdk 9, and default to android platform version 28
 * Bump reflex-dom 0.5.2

--- a/default.nix
+++ b/default.nix
@@ -83,6 +83,7 @@ let iosSupport = system == "x86_64-darwin";
         mobileGhcOverlay
         allCabalHashesOverlay
         splicesEval
+        (import ./nixpkgs-overlays/ghc.nix { inherit lib; })
       ] ++ nixpkgsOverlays;
       config = {
         permittedInsecurePackages = [

--- a/nixpkgs-overlays/ghc.nix
+++ b/nixpkgs-overlays/ghc.nix
@@ -1,0 +1,16 @@
+{ lib }:
+
+self: super: {
+  # Apply custom patches to Haskell compilers
+  haskell = super.haskell // {
+    compiler = super.haskell.compiler // lib.mapAttrs (n: v: v.overrideAttrs (drv: {
+      patches = (drv.patches or []) ++ [
+        # Fix a segfault in base reported in https://gitlab.haskell.org/ghc/ghc/issues/16893
+        (self.fetchpatch {
+          url = "https://gitlab.haskell.org/ghc/ghc/commit/220ab887a4f009d9da8b2336d228d9f8eaf4aacc.patch";
+          sha256 = "1qjvjxbn8xczmxm8pc9vxnqwn2nx0xyfm0ifkpa3sqswy3a09x9j";
+        })
+      ];
+    })) { inherit (super.haskell.compiler) ghc865; };
+  };
+}


### PR DESCRIPTION
Applies workaround patch for
https://gitlab.haskell.org/ghc/ghc/issues/16893 to avoid a segfault.
This fix was originally applied to GHC-8.8, but not GHC-8.6. Manually
applying it in reflex-platform to fix the issue in all Reflex
projects.