### PR TITLE
Improvements to workOn multi and friends

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -19,6 +19,8 @@ This project's release branch is `master`. This log is written from the perspect
   of a package set. Now they have a `{ nativeHaskellPackages ? ghc }` parameter
   so either `{}` can be passed, in which case it will use the default `ghc`,
   or `{ nativeHaskellPackages = ..; }` to pass a package set as before.
+  These attributes are exposed but not widely used (to our knowledge). They are
+  mainly just used from `scripts/work-on*`, whose interface is unchanged.
 
 ## v0.1.0.0 - 2019-04-03
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,10 @@ This project's release branch is `master`. This log is written from the perspect
 * Update to the nixos-19.03 nixpkgs channel
 * Update to gradle build tools 3.1.0, androidsdk 9, and default to android platform version 28
 * Bump reflex-dom 0.5.2
+* Before, `generalDevTools`, and `generalDevToolsAttrs` took a single argument
+  of a package set. Now they have a `{ nativeHaskellPackages ? ghc }` parameter
+  so either `{}` can be passed, in which case it will use the default `ghc`,
+  or `{ nativeHaskellPackages = ..; }` to pass a package set as before.
 
 ## v0.1.0.0 - 2019-04-03
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -53,18 +53,10 @@ considered released, and the date should reflect that release.
 
    * `generalDevTools`
    * `generalDevToolsAttrs`
+   * `nativeHaskellPackages`
 
-  They are replaced with:
-
-   * `generalDevTools'`
-   * `generalDevToolsAttrs'`
-
-  The old ones takes a single argument of a package set.  Their replacements
-  have a `{ nativeHaskellPackages ? ghc }` parameter so either `{}` can be
-  passed, in which case it will use the default `ghc`, or `{
-  nativeHaskellPackages = ..; }` to pass a package set as before.  These
-  attributes are exposed but not widely used (to our knowledge). They are
-  mainly just used from `scripts/work-on*`, whose interface is unchanged.
+  The are exposed for now for backwards compat, but will be removed at a later
+  point. They are mainly used in the implementation of the `work-on*` scripts.
 
 ## v0.1.0.0 - 2019-04-03
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -21,6 +21,7 @@ This project's release branch is `master`. This log is written from the perspect
   or `{ nativeHaskellPackages = ..; }` to pass a package set as before.
   These attributes are exposed but not widely used (to our knowledge). They are
   mainly just used from `scripts/work-on*`, whose interface is unchanged.
+* Fix work-on-multi to respect the do-check of the haskell-config derivations
 
 ## v0.1.0.0 - 2019-04-03
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,31 +1,39 @@
 # Revision history for reflex-platform
 
-This project's release branch is `master`. This log is written from the perspective of the release branch: when changes hit `master`, they are considered released, and the date should reflect that release.
+This project's release branch is `master`. This log is written from the
+perspective of the release branch: when changes hit `master`, they are
+considered released, and the date should reflect that release.
 
 ## Unreleased
 
-* Document how to accept android sdk license agreement and pass acceptance through to android infrastructure.
+* Document how to accept android sdk license agreement and pass acceptance
+  through to android infrastructure.
+
 * Update to GHC(JS) 8.6.5
   * Apply workaround patch for
     [ghc#16893](https://gitlab.haskell.org/ghc/ghc/issues/16893),
     avoiding segmentation fault when using base.
+
 * Update to the nixos-19.03 nixpkgs channel
-* Update to gradle build tools 3.1.0, androidsdk 9, and default to android platform version 28
+
+* Update to gradle build tools 3.1.0, androidsdk 9, and default to android
+  platform version 28
+
 * Bump reflex-dom 0.5.2
+
 * Fixes an inconsistency between nix-shell and nix-build where certain
   Haskell build tools were not being overriden
   ([#548](https://github.com/reflex-frp/reflex-platform/pull/548)
+
 * Removing long-since-broken `nixpkgs.haskell.compiler.ghcSplices` attribute,
   leaving behind `nixpkgs.haskell.compiler.ghcSplices-8_6`, which is its
   intended replacement.
-* `zlib` for mobile doesn't provide any `*.so`/`.dylib`, that way you are guaranteed to link the `.a` and not one of the others by mistake.
-* Before, `generalDevTools`, and `generalDevToolsAttrs` took a single argument
-  of a package set. Now they have a `{ nativeHaskellPackages ? ghc }` parameter
-  so either `{}` can be passed, in which case it will use the default `ghc`,
-  or `{ nativeHaskellPackages = ..; }` to pass a package set as before.
-  These attributes are exposed but not widely used (to our knowledge). They are
-  mainly just used from `scripts/work-on*`, whose interface is unchanged.
+
+* `zlib` for mobile doesn't provide any `*.so`/`.dylib`, that way you are
+  guaranteed to link the `.a` and not one of the others by mistake.
+
 * Fix work-on-multi to respect the do-check of the haskell-config derivations
+
 * The following attributes have been deprecated in `default.nix`, and are now
   defined in `nix-utils/hackage.nix`:
 
@@ -41,16 +49,35 @@ This project's release branch is `master`. This log is written from the perspect
   These are only useful to the maintainers of packages in reflex platform, and
   just clutter the top level for everyone else.
 
+* Deprecate:
+
+   * `generalDevTools`
+   * `generalDevToolsAttrs`
+
+  They are replaced with:
+
+   * `generalDevTools'`
+   * `generalDevToolsAttrs'`
+
+  The old ones takes a single argument of a package set.  Their replacements
+  have a `{ nativeHaskellPackages ? ghc }` parameter so either `{}` can be
+  passed, in which case it will use the default `ghc`, or `{
+  nativeHaskellPackages = ..; }` to pass a package set as before.  These
+  attributes are exposed but not widely used (to our knowledge). They are
+  mainly just used from `scripts/work-on*`, whose interface is unchanged.
+
 ## v0.1.0.0 - 2019-04-03
 
 * Move git "thunks" to `dep/` dirs within each overlay, rather than one big
   `dep/` directory at the top level. This does make checking out thunks a bit
   more involved, but has the benefit of untangling reflex-platform a bit and
   making it more modular.
+
 * Many of the overlays have a `_dep` attribute with all the source derivations
   introduced by the overlay. This is just so `release.nix` can build all the
   sources, ensuring that these build-time dependencies also make it to the
   cache. This attribute is *not* intended to be overridden by consumers of
   reflex-platform. In particular it's possible the way we now push to the cache
   doesn't need this, and it will be removed entirely.
+
 * Remove support for GHCs older than 8.4.

--- a/default.nix
+++ b/default.nix
@@ -352,7 +352,7 @@ in let this = rec {
   ];
 
   # Tools that are useful for development under both ghc and ghcjs
-  generalDevToolsAttrs = { nativeHaskellPackages ? ghc }: {
+  generalDevToolsAttrs' = { nativeHaskellPackages ? ghc }: {
     inherit (nativeHaskellPackages)
       Cabal
       cabal-install
@@ -375,7 +375,7 @@ in let this = rec {
     }).haskell-ide-engine;
   };
 
-  generalDevTools = { nativeHaskellPackages ? ghc }: builtins.attrValues (generalDevToolsAttrs { inherit nativeHaskellPackages; });
+  generalDevTools' = { nativeHaskellPackages ? ghc }: builtins.attrValues (generalDevToolsAttrs' { inherit nativeHaskellPackages; });
 
   nativeHaskellPackages = haskellPackages:
     if haskellPackages.isGhcjs or false
@@ -383,7 +383,7 @@ in let this = rec {
     else haskellPackages;
 
   workOn = haskellPackages: package: (overrideCabal package (drv: {
-    buildDepends = (drv.buildDepends or []) ++ generalDevTools { nativeHaskellPackages = nativeHaskellPackages haskellPackages; };
+    buildDepends = (drv.buildDepends or []) ++ generalDevTools' { nativeHaskellPackages = nativeHaskellPackages haskellPackages; };
   })).env;
 
   workOnMulti' = { env, packageNames, tools ? _: [], shellToolOverrides ? _: _: {} }:
@@ -437,7 +437,7 @@ in let this = rec {
           };
         })).out;
         notInTargetPackageSet = p: all (pname: (p.pname or "") != pname) packageNames;
-        baseTools = generalDevToolsAttrs {};
+        baseTools = generalDevToolsAttrs' {};
         overriddenTools = baseTools // shellToolOverrides env baseTools;
         depAttrs = lib.mapAttrs (_: v: filter notInTargetPackageSet v) (concatCombinableAttrs (concatLists [
           (map getHaskellConfig (lib.attrVals packageNames env))
@@ -485,7 +485,7 @@ in let this = rec {
       inherit platform;
     });
 
-  tryReflexPackages = generalDevTools {}
+  tryReflexPackages = generalDevTools' {}
     ++ builtins.map reflexEnv platforms;
 
   cachePackages =
@@ -525,6 +525,8 @@ legacy = {
     mkReleaseCandidate
     releaseCandidates
     ;
+  generalDevTools = _: generalDevTools' {};
+  generalDevToolsAttrs = _: generalDevToolsAttrs' {};
 };
 
 in this // lib.optionalAttrs (!hideDeprecated) legacy

--- a/default.nix
+++ b/default.nix
@@ -525,8 +525,8 @@ legacy = {
     mkReleaseCandidate
     releaseCandidates
     ;
-  generalDevTools = _: generalDevTools' {};
-  generalDevToolsAttrs = _: generalDevToolsAttrs' {};
+  generalDevTools = _: this.generalDevTools' {};
+  generalDevToolsAttrs = _: this.generalDevToolsAttrs' {};
 };
 
 in this // lib.optionalAttrs (!hideDeprecated) legacy

--- a/default.nix
+++ b/default.nix
@@ -259,6 +259,32 @@ let iosSupport = system == "x86_64-darwin";
     buildApp = nixpkgs.lib.makeOverridable (import ./ios { inherit nixpkgs ghc; });
   };
 
+  # Tools that are useful for development under both ghc and ghcjs
+  generalDevToolsAttrs = { nativeHaskellPackages ? ghc }: {
+    inherit (nativeHaskellPackages)
+      Cabal
+      cabal-install
+      ghcid
+      hasktags
+      hdevtools
+      hlint
+      stylish-haskell # Recent stylish-haskell only builds with AMP in place
+      ;
+    inherit (nixpkgs)
+      cabal2nix
+      curl
+      nix-prefetch-scripts
+      nodejs
+      pkgconfig
+      closurecompiler
+      ;
+    haskell-ide-engine = nixpkgs.haskell.lib.justStaticExecutables (nativeHaskellPackages.override {
+      overrides = nixpkgs.haskell.overlays.hie;
+    }).haskell-ide-engine;
+  };
+
+  generalDevTools = { nativeHaskellPackages ? ghc }: builtins.attrValues (generalDevToolsAttrs { inherit nativeHaskellPackages; });
+
 in let this = rec {
   inherit (nixpkgs)
     filterGit
@@ -351,39 +377,8 @@ in let this = rec {
     nixpkgs.androidsdk_9_0
   ];
 
-  # Tools that are useful for development under both ghc and ghcjs
-  generalDevToolsAttrs' = { nativeHaskellPackages ? ghc }: {
-    inherit (nativeHaskellPackages)
-      Cabal
-      cabal-install
-      ghcid
-      hasktags
-      hdevtools
-      hlint
-      stylish-haskell # Recent stylish-haskell only builds with AMP in place
-      ;
-    inherit (nixpkgs)
-      cabal2nix
-      curl
-      nix-prefetch-scripts
-      nodejs
-      pkgconfig
-      closurecompiler
-      ;
-    haskell-ide-engine = nixpkgs.haskell.lib.justStaticExecutables (nativeHaskellPackages.override {
-      overrides = nixpkgs.haskell.overlays.hie;
-    }).haskell-ide-engine;
-  };
-
-  generalDevTools' = { nativeHaskellPackages ? ghc }: builtins.attrValues (generalDevToolsAttrs' { inherit nativeHaskellPackages; });
-
-  nativeHaskellPackages = haskellPackages:
-    if haskellPackages.isGhcjs or false
-    then haskellPackages.ghc
-    else haskellPackages;
-
   workOn = haskellPackages: package: (overrideCabal package (drv: {
-    buildDepends = (drv.buildDepends or []) ++ generalDevTools' { nativeHaskellPackages = nativeHaskellPackages haskellPackages; };
+    buildDepends = (drv.buildDepends or []) ++ generalDevTools {};
   })).env;
 
   workOnMulti' = { env, packageNames, tools ? _: [], shellToolOverrides ? _: _: {} }:
@@ -437,7 +432,7 @@ in let this = rec {
           };
         })).out;
         notInTargetPackageSet = p: all (pname: (p.pname or "") != pname) packageNames;
-        baseTools = generalDevToolsAttrs' {};
+        baseTools = generalDevToolsAttrs {};
         overriddenTools = baseTools // shellToolOverrides env baseTools;
         depAttrs = lib.mapAttrs (_: v: filter notInTargetPackageSet v) (concatCombinableAttrs (concatLists [
           (map getHaskellConfig (lib.attrVals packageNames env))
@@ -460,7 +455,7 @@ in let this = rec {
       license = null;
     })).env;
 
-  workOnMulti = env: packageNames: workOnMulti' { inherit env packageNames; };
+  workOnMulti = env: packageNames: workOnMulti { inherit env packageNames; };
 
   # A simple derivation that just creates a file with the names of all
   # of its inputs. If built, it will have a runtime dependency on all
@@ -485,7 +480,7 @@ in let this = rec {
       inherit platform;
     });
 
-  tryReflexPackages = generalDevTools' {}
+  tryReflexPackages = generalDevTools {}
     ++ builtins.map reflexEnv platforms;
 
   cachePackages =
@@ -525,8 +520,12 @@ legacy = {
     mkReleaseCandidate
     releaseCandidates
     ;
-  generalDevTools = _: this.generalDevTools' {};
-  generalDevToolsAttrs = _: this.generalDevToolsAttrs' {};
+  generalDevTools = _: this.generalDevTools {};
+  generalDevToolsAttrs = _: this.generalDevToolsAttrs {};
+  nativeHaskellPackages = haskellPackages:
+    if haskellPackages.isGhcjs or false
+    then haskellPackages.ghc
+    else haskellPackages;
 };
 
 in this // lib.optionalAttrs (!hideDeprecated) legacy

--- a/haskell-overlays/untriaged.nix
+++ b/haskell-overlays/untriaged.nix
@@ -84,6 +84,7 @@ in self: super: {
   semialign = doJailbreak (self.callHackage "semialign" "1" {});
   these = self.callHackage "these" "1" {};
   these-lens = self.callHackage "these-lens" "1" {};
+  which = self.callHackage "which" "0.1.0.0" {};
 
   ########################################################################
   # Packages not in hackage


### PR DESCRIPTION
In 4f0d01963de36f2691d0ee03e892993c0473f721 we made
`nativeHaskellPackages` always close over the `ghc` that came with
reflex-platform. This means that app-specific overrides won't cause the
needless rebuilding of these tools. `haskell-ide-engine` however wasn't
using this, and so would be rebuilt.

This fixes everything to use `ghc` by making `nativeHaskellPackages` a
pattern argument so it can have `ghc` as a default.

It also ensures that test dependencies are built for `doCheck = false` packages. This is good for working on nonnative builds such as ghcjs or mobile ones.