### PR TITLE
jailbreak these-lens so that reflex's own tests can pass correctly 

### DIFF
--- a/haskell-overlays/untriaged.nix
+++ b/haskell-overlays/untriaged.nix
@@ -83,7 +83,8 @@ in self: super: {
   # Packages not yet in 19.03
   semialign = doJailbreak (self.callHackage "semialign" "1" {});
   these = self.callHackage "these" "1" {};
-  these-lens = self.callHackage "these-lens" "1" {};
+  these-lens = doJailbreak (self.callHackage "these-lens" "1" {});
+  # these-lens wants an old lens version for no particular reason
   which = self.callHackage "which" "0.1.0.0" {};
 
   ########################################################################

--- a/haskell-overlays/untriaged.nix
+++ b/haskell-overlays/untriaged.nix
@@ -84,7 +84,7 @@ in self: super: {
   semialign = doJailbreak (self.callHackage "semialign" "1" {});
   these = self.callHackage "these" "1" {};
   these-lens = doJailbreak (self.callHackage "these-lens" "1" {});
-  # these-lens wants an old lens version for no particular reason
+  # remove jailbreak after https://github.com/isomorphism/these/pull/134
   which = self.callHackage "which" "0.1.0.0" {};
 
   ########################################################################


### PR DESCRIPTION
since reflex's tests depend on reflex-platform