### PR TITLE
Bump all cabal hashes

### DIFF
--- a/nixpkgs-overlays/all-cabal-hashes/default.nix
+++ b/nixpkgs-overlays/all-cabal-hashes/default.nix
@@ -1,8 +1,8 @@
 self: _: {
 
   all-cabal-hashes = self.fetchurl {
-    url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/5ab6d775bc21c819e332114318b7f738c26794f5.tar.gz";
-    sha256 = "1565lgias16n03jxjzmh060952xlgbxaa76k4n8d8ynjl2zf1d6k";
+    url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/ee09c1a8adf86198469e53e7a86f3c2d7940fc58.tar.gz";
+    sha256 = "1z8lmj4gn311qf3pilsc2ckb8bnkrjc95ddhjwb2a0760h1wmb5h";
   };
 
 }


### PR DESCRIPTION
This sadly changes hashes, because `cabal2nix` in nixpkgs was made to sneak in a reference to the imported derivation as a work around for Nix not currently being able to record the eval-time closure (CC @danbornside who knows about that all too well).

We ought to fix that in Nix of course, at which point we ought to change back `cabal2nix` to not pollute the hashes with this information. At that point, future bumps like this will preserve hashes and be trivial to QA.