### PR TITLE
Add ability to override haskell packages before other overrides

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -10,8 +10,8 @@
 , iosSdkVersion ? "10.2"
 , nixpkgsOverlays ? []
 , haskellOverlays ? [] # TODO deprecate
-, haskellOverlaysPre ? haskellOverlays
-, haskellOverlaysPost ? []
+, haskellOverlaysPre ? []
+, haskellOverlaysPost ? haskellOverlays
 }:
 let iosSupport = system == "x86_64-darwin";
     androidSupport = lib.elem system [ "x86_64-linux" ];

--- a/default.nix
+++ b/default.nix
@@ -9,7 +9,9 @@
 , useTextJSString ? true # Use an implementation of "Data.Text" that uses the more performant "Data.JSString" from ghcjs-base under the hood.
 , iosSdkVersion ? "10.2"
 , nixpkgsOverlays ? []
-, haskellOverlays ? []
+, haskellOverlays ? [] # TODO deprecate
+, haskellOverlaysPre ? haskellOverlays
+, haskellOverlaysPost ? []
 }:
 let iosSupport = system == "x86_64-darwin";
     androidSupport = lib.elem system [ "x86_64-linux" ];
@@ -51,7 +53,8 @@ let iosSupport = system == "x86_64-darwin";
           inherit
             useFastWeak useReflexOptimizer enableLibraryProfiling enableTraceReflexEvents
             useTextJSString enableExposeAllUnfoldings
-            haskellOverlays;
+            haskellOverlaysPre
+            haskellOverlaysPost;
           inherit ghcSavedSplices;
         };
       };

--- a/haskell-overlays/default.nix
+++ b/haskell-overlays/default.nix
@@ -4,7 +4,8 @@
 , useFastWeak, useReflexOptimizer, enableLibraryProfiling, enableTraceReflexEvents
 , useTextJSString, enableExposeAllUnfoldings
 , ghcSavedSplices
-, haskellOverlays
+, haskellOverlaysPre
+, haskellOverlaysPost
 }:
 
 let
@@ -35,6 +36,8 @@ rec {
   # overlay. At the cost of violating the usual rules on using `self` vs
   # `super`, this avoids a bunch of strictness issues keeping us terminating.
   combined = self: super: foldExtensions [
+    user-custom-pre
+
     reflexPackages
     untriaged
 
@@ -50,7 +53,7 @@ rec {
     (optionalExtension (nixpkgs.stdenv.hostPlatform.useAndroidPrebuilt or false) android)
     (optionalExtension (nixpkgs.stdenv.hostPlatform.isiOS or false) ios)
 
-    user-custom
+    user-custom-post
   ] self super;
 
   combined-any = self: super: foldExtensions [
@@ -141,5 +144,6 @@ rec {
     inherit thunkSet;
   };
 
-  user-custom = foldExtensions haskellOverlays;
+  user-custom-pre = foldExtensions haskellOverlaysPre;
+  user-custom-post = foldExtensions haskellOverlaysPost;
 }


### PR DESCRIPTION
This is useful to bump a version without disabling reflex-platform's
other overrides. There ought to be a better way to do this than messing
with sequential orders, but this is fine for now.