### PR TITLE
WIP: Add secret __useTemplateHaskell for CI

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -7,6 +7,7 @@
 , useFastWeak ? true
 , useReflexOptimizer ? false
 , useTextJSString ? true # Use an implementation of "Data.Text" that uses the more performant "Data.JSString" from ghcjs-base under the hood.
+, __useTemplateHaskell ? true # Deprecated, just here until we remove feature from reflex and stop CIing it
 , iosSdkVersion ? "10.2"
 , nixpkgsOverlays ? []
 , haskellOverlays ? [] # TODO deprecate
@@ -52,7 +53,7 @@ let iosSupport = system == "x86_64-darwin";
           haskellLib = self.haskell.lib;
           inherit
             useFastWeak useReflexOptimizer enableLibraryProfiling enableTraceReflexEvents
-            useTextJSString enableExposeAllUnfoldings
+            useTextJSString enableExposeAllUnfoldings __useTemplateHaskell
             haskellOverlaysPre
             haskellOverlaysPost;
           inherit ghcSavedSplices;

--- a/haskell-overlays/default.nix
+++ b/haskell-overlays/default.nix
@@ -2,7 +2,7 @@
 , haskellLib
 , nixpkgs
 , useFastWeak, useReflexOptimizer, enableLibraryProfiling, enableTraceReflexEvents
-, useTextJSString, enableExposeAllUnfoldings
+, useTextJSString, enableExposeAllUnfoldings, __useTemplateHaskell
 , ghcSavedSplices
 , haskellOverlaysPre
 , haskellOverlaysPost
@@ -85,7 +85,7 @@ rec {
   reflexPackages = import ./reflex-packages {
     inherit
       haskellLib lib nixpkgs thunkSet fetchFromGitHub fetchFromBitbucket
-      useFastWeak useReflexOptimizer enableTraceReflexEvents enableLibraryProfiling
+      useFastWeak useReflexOptimizer enableTraceReflexEvents enableLibraryProfiling __useTemplateHaskell
       ;
   };
   exposeAllUnfoldings = import ./expose-all-unfoldings.nix { };

--- a/haskell-overlays/default.nix
+++ b/haskell-overlays/default.nix
@@ -83,7 +83,10 @@ rec {
   ##
 
   reflexPackages = import ./reflex-packages {
-    inherit haskellLib lib nixpkgs thunkSet fetchFromGitHub useFastWeak useReflexOptimizer enableTraceReflexEvents enableLibraryProfiling fetchFromBitbucket;
+    inherit
+      haskellLib lib nixpkgs thunkSet fetchFromGitHub fetchFromBitbucket
+      useFastWeak useReflexOptimizer enableTraceReflexEvents enableLibraryProfiling
+      ;
   };
   exposeAllUnfoldings = import ./expose-all-unfoldings.nix { };
   textJSString = import ./text-jsstring {

--- a/haskell-overlays/reflex-packages/default.nix
+++ b/haskell-overlays/reflex-packages/default.nix
@@ -1,7 +1,7 @@
 { haskellLib
 , lib, nixpkgs
 , thunkSet, fetchFromGitHub, fetchFromBitbucket
-, useFastWeak, useReflexOptimizer, enableTraceReflexEvents, enableLibraryProfiling
+, useFastWeak, useReflexOptimizer, enableTraceReflexEvents, enableLibraryProfiling, __useTemplateHaskell
 }:
 
 with haskellLib;
@@ -16,6 +16,7 @@ let
   ghcjsDom = import self._dep.ghcjs-dom self;
 
   reflexOptimizerFlag = lib.optional (useReflexOptimizer && (self.ghc.cross or null) == null) "-fuse-reflex-optimizer";
+  useTemplateHaskellFlag = lib.optional (!__useTemplateHaskell) "-f-use-template-haskell";
 
   inherit (nixpkgs) stdenv;
 in
@@ -29,6 +30,7 @@ in
   reflex = self.callCabal2nixWithOptions "reflex" self._dep.reflex (lib.concatStringsSep " " (lib.concatLists [
     (lib.optional enableTraceReflexEvents "-fdebug-trace-events")
     reflexOptimizerFlag
+    useTemplateHaskellFlag
     (lib.optional useFastWeak "-ffast-weak")
   ])) {};
 
@@ -44,6 +46,7 @@ in
     (self.callCabal2nixWithOptions "reflex-dom-core" reflexDomRepo (lib.concatStringsSep " " (lib.concatLists [
       ["--subpath reflex-dom-core"]
       reflexOptimizerFlag
+      useTemplateHaskellFlag
       (lib.optional enableLibraryProfiling "-fprofile-reflex")
     ])) {})
     (drv: {
@@ -82,6 +85,7 @@ in
     (self.callCabal2nixWithOptions "reflex-dom" reflexDomRepo (lib.concatStringsSep " " (lib.concatLists [
       ["--subpath reflex-dom"]
       reflexOptimizerFlag
+      useTemplateHaskellFlag
     ])) {})
     (drv: {
       # Hack until https://github.com/NixOS/cabal2nix/pull/432 lands


### PR DESCRIPTION
I am trying to get reflex to rely on reflex-platform more for CI. Reflex
has the ability to not use Template Haskell, which we no longer care
about but do CI as we haven't reused this. I want to make the
transition without modifiying features, so I am temporarily adding this
as a deprecated "east egg" to reflex-platform so that I can use it from
reflex's CI.