### PR TITLE
Fix static build of zlib for mobile

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,6 +18,7 @@ This project's release branch is `master`. This log is written from the perspect
 * Removing long-since-broken `nixpkgs.haskell.compiler.ghcSplices` attribute,
   leaving behind `nixpkgs.haskell.compiler.ghcSplices-8_6`, which is its
   intended replacement.
+* `zlib` for mobile doesn't provide any `*.so`/`.dylib`, that way you are guaranteed to link the `.a` and not one of the others by mistake.
 
 ## v0.1.0.0 - 2019-04-03
 

--- a/default.nix
+++ b/default.nix
@@ -70,7 +70,7 @@ let iosSupport = system == "x86_64-darwin";
       };
       zlib = super.zlib.override (lib.optionalAttrs
         (self.stdenv.hostPlatform != self.stdenv.buildPlatform)
-        { static = true; });
+        { static = true; shared = false; });
     };
 
     mobileGhcOverlay = import ./nixpkgs-overlays/mobile-ghc { inherit lib; };


### PR DESCRIPTION
This fixes #573, when rebased off aa8a9d1ac3d41ad51fbe04e575d4350da65cf3db (the version `obelisk` currently uses). On `develop` I hit https://github.com/reflex-frp/reflex-platform/issues/575, but this PR presumably would still work.

The relevant line in `nixpkgs` is

```
  configureFlags = stdenv.lib.optional shared "--shared"
                   ++ stdenv.lib.optional (static && !shared) "--static";
```

in `pkgs/development/libraries/zlib/default.nix`.