### PR TITLE
Use public https://gitlab.haskell.org for ghc dep

### DIFF
--- a/haskell-overlays/splices-load-save/dep/ghc/git.json
+++ b/haskell-overlays/splices-load-save/dep/ghc/git.json
@@ -1,5 +1,5 @@
 {
-  "url": "git@gitlab.haskell.org:obsidiansystems/ghc",
+  "url": "https://gitlab.haskell.org/obsidiansystems/ghc.git",
   "rev": "c832deafcabe36022abe217538d4347ace6abee2",
   "sha256": "0i024m5skvii7q9hyj87zra625ws5ss5knq7lrcbcs3fhaa6pq5j",
   "fetchSubmodules": true


### PR DESCRIPTION
This let’s users without ssh-config-* settings build reflex-platform.
Since this repo is public, we can just use https protocol.