### PR TITLE
Fix the android crash by reverting the old fix to the android crash

### DIFF
--- a/android/impl.nix
+++ b/android/impl.nix
@@ -78,7 +78,7 @@ in {
           name = applicationId + "-java";
           paths = [
             (ghcAndroidAarch64.android-activity.src + "/java") #TODO: Use output, not src
-            (ghcAndroidAarch64.reflex-dom.src + "/reflex-dom/java")
+            (ghcAndroidAarch64.reflex-dom.src + "/java")
           ];
         };
         src = ./src;


### PR DESCRIPTION
In 28a2a13ea79ebdfdd4d6c4d1fe5bf412f2ad1eaf we switched from passing `--subdir` to `cabal2nix` in order to fish out the the source from within the repo to doing `src = repo + "/subdir`. This changes what the `src` attribute looks like, as `cabal2nix` adds an extra `cd ... command` to a hook rather than computing a different `src` attribute. As such, we need to revert the way the android app is built so the relative path to the `java/` directory is once again correct.