### PR TITLE
Remove the `android/stubs.c` deletion entry

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,10 +4,6 @@ This project's release branch is `master`. This log is written from the
 perspective of the release branch: when changes hit `master`, they are
 considered released, and the date should reflect that release.
 
-## Unreleased
-
-* Remove unused `android/stubs.c`
-
 ## v0.2.0.0 - 2019-12-24
 
 * Upgrade reflex packages:


### PR DESCRIPTION
I was confused; it really is dead code and its removal doesn't change
any hashes. This is not an interface change there, and doesn't need to clutter the git log.