### PR TITLE
Support both Apple Development and iPhone Developer certificates.

### DIFF
--- a/ios/default.nix
+++ b/ios/default.nix
@@ -163,7 +163,7 @@ nixpkgs.runCommand "${executableName}-app" (rec {
 
     tmpdir=$(mktemp -d)
     # Find the signer given the OU
-    signer=$(security find-certificate -c 'iPhone Developer' -c 'Apple Development' -a \
+    signer=$({ security find-certificate -c 'iPhone Developer' -a; security find-certificate -c 'Apple Development' -a; } \
       | grep '^    "alis"<blob>="' \
       | sed 's|    "alis"<blob>="\(.*\)"$|\1|' \
       | while read c; do \

--- a/scripts/ios-deploy-todomvc.sh
+++ b/scripts/ios-deploy-todomvc.sh
@@ -17,7 +17,7 @@ fi
 
 tmpdir=$(mktemp -d)
 # Find the signer given the OU
-signer=$(security find-certificate -c "iPhone Developer" -a \
+signer=$({ security find-certificate -c 'iPhone Developer' -a; security find-certificate -c 'Apple Development' -a; } \
   | grep '^    "alis"<blob>="' \
   | sed 's|    "alis"<blob>="\(.*\)"$|\1|' \
   | while read c; do security find-certificate -c "$c" -p \


### PR DESCRIPTION
The previous fix was just ignoring the first `-c`, this contatenates the outputs to
find either versions. On single developer machines, this will work fine as there is only one
but on shared machines where there are keys in the system keychain and not only in the login
keychain users will be unable to deploy until they delete all others from the system keychain
and that has to be done by the user that put it in the first place.

A fix for multi user systems would be to accept the developer id in either default.nix or
to accept it in the deploy script.