### PR TITLE
Fix regexes in deploy scripts.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,11 @@ This project's release branch is `master`. This log is written from the
 perspective of the release branch: when changes hit `master`, they are
 considered released, and the date should reflect that release.
 
+## Unreleased
+
+* Make script iOS deploy more flexible.
+  Splaces on either side of the `=` printed out by Apple's `security find-certificate` command for the team ID are now accepted.
+
 ## v0.4.2.0 - 2020-01-15
 
 * Add haskell overlays for `reflex-process`, `reflex-fsnotify`, and `reflex-vty`

--- a/ios/default.nix
+++ b/ios/default.nix
@@ -170,7 +170,7 @@ nixpkgs.runCommand "${executableName}-app" (rec {
           security find-certificate -c "$c" -p \
             | openssl x509 -subject -noout; \
         done \
-      | grep "OU=$TEAM_ID/" \
+      | grep "OU[[:space:]]\?=[[:space:]]\?$TEAM_ID" \
       | sed 's|subject= /UID=[^/]*/CN=\([^/]*\).*|\1|' \
       | head -n 1 || true)
 
@@ -226,7 +226,7 @@ nixpkgs.runCommand "${executableName}-app" (rec {
           security find-certificate -c "$c" -p \
             | openssl x509 -subject -noout; \
         done \
-      | grep "OU=$TEAM_ID/" \
+      | grep "OU[[:space:]]\?=[[:space:]]\?$TEAM_ID" \
       | sed 's|subject= /UID=[^/]*/CN=\([^/]*\).*|\1|' \
       | head -n 1)
 


### PR DESCRIPTION
Testing has shown that the openssl command's output may contain spaces at the
relevant places.  Therefore we need optional spaces there.  Similar issues with
the surrounding sed and grep commands may remain, however.

Relates to issue #616.