### PR TITLE
Use Nixpkgs LibreSSL explicitly.

### DIFF
--- a/ios/default.nix
+++ b/ios/default.nix
@@ -168,7 +168,7 @@ nixpkgs.runCommand "${executableName}-app" (rec {
       | sed 's|    "alis"<blob>="\(.*\)"$|\1|' \
       | while read c; do \
           security find-certificate -c "$c" -p \
-            | openssl x509 -subject -noout; \
+            | ${nixpkgs.libressl}/bin/openssl x509 -subject -noout; \
         done \
       | grep "OU[[:space:]]\?=[[:space:]]\?$TEAM_ID" \
       | sed 's|subject= /UID=[^/]*/CN=\([^/]*\).*|\1|' \
@@ -224,7 +224,7 @@ nixpkgs.runCommand "${executableName}-app" (rec {
       | sed 's|    "alis"<blob>="\(.*\)"$|\1|' \
       | while read c; do \
           security find-certificate -c "$c" -p \
-            | openssl x509 -subject -noout; \
+            | ${nixpkgs.libressl}/bin/openssl x509 -subject -noout; \
         done \
       | grep "OU[[:space:]]\?=[[:space:]]\?$TEAM_ID" \
       | sed 's|subject= /UID=[^/]*/CN=\([^/]*\).*|\1|' \


### PR DESCRIPTION
In some situations, we may be getting either OpenSSL or LibreSSL from the macOS
system environment, which, as it turns out, output X.509 parsed data in slightly
different formats.  Invoking the Nixpkgs-provided LibreSSL in the deploy script
instead helps us resolve this discrepancy.  Addresses #616.