### PR TITLE
Verify .json is only file in directory for hackGet

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,7 +8,7 @@ considered released, and the date should reflect that release.
 
 * Throw an error in hackGet when files other than the git/github.json
   and default.nix are there. This is a common problem when
-  git/github.json exist in an unpacked thunked.
+  git/github.json exist in an unpacked thunk.
 
 ## v0.5.1.0 - 2020-01-22
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,12 @@ This project's release branch is `master`. This log is written from the
 perspective of the release branch: when changes hit `master`, they are
 considered released, and the date should reflect that release.
 
+## Unreleased
+
+* Throw an error in hackGet when files other than the git/github.json
+  and default.nix are there. This is a common problem when
+  git/github.json exist in an unpacked thunked.
+
 ## v0.5.1.0 - 2020-01-22
 
 * Bump `reflex` to `0.6.4`.

--- a/nixpkgs-overlays/hack-get/default.nix
+++ b/nixpkgs-overlays/hack-get/default.nix
@@ -7,13 +7,21 @@ self:
 
   # Retrieve source that is controlled by the hack-* scripts; it may be either a stub or a checked-out git repo
   hackGet = p:
-    let filterArgs = x: removeAttrs x [ "branch" ];
-    in if builtins.pathExists (p + "/git.json") then (
+    let
+      filterArgs = x: removeAttrs x [ "branch" ];
+      hasValidThunk = name: if builtins.pathExists (p + ("/" + name))
+        then (let contents = builtins.readDir p;
+              in if contents == { ${name} = "regular"; } || contents == { ${name} = "regular"; "default.nix" = "regular"; }
+                 then true
+                 else throw "Thunk at ${toString p} has files in addition to ${name} and default.nix. Remove either ${name} or those other files to continue.")
+        else false;
+    in if hasValidThunk "git.json" then (
       let gitArgs = filterArgs (builtins.fromJSON (builtins.readFile (p + "/git.json")));
       in if builtins.elem "@" (lib.stringToCharacters gitArgs.url)
       then self.fetchgitPrivate gitArgs
       else self.fetchgit gitArgs)
-    else if builtins.pathExists (p + "/github.json") then self.fetchFromGitHub (filterArgs (builtins.fromJSON (builtins.readFile (p + "/github.json"))))
+    else if hasValidThunk "github.json" then
+      self.fetchFromGitHub (filterArgs (builtins.fromJSON (builtins.readFile (p + "/github.json"))))
     else {
       name = baseNameOf p;
       outPath = self.filterGit p;


### PR DESCRIPTION
This throws an error when the git/github.json and default.nix file are
not the only file(s) in the thunk directory. This is a common issue
when users accidentally forget to remove the .json after they’ve
unpacked a thunk. Note that default.nix is optional and occasionally
provided in repo’s that are hackGet’d.