### PR TITLE
Remove thunks without default.nix

### DIFF
--- a/haskell-overlays/reflex-packages/dep/patch/default.nix
+++ b/haskell-overlays/reflex-packages/dep/patch/default.nix
@@ -1,8 +1,0 @@
-# DO NOT HAND-EDIT THIS FILE
-let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
-  if !fetchSubmodules && !private then builtins.fetchTarball {
-    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
-  } else (import <nixpkgs> {}).fetchFromGitHub {
-    inherit owner repo rev sha256 fetchSubmodules private;
-  };
-in import (fetch (builtins.fromJSON (builtins.readFile ./github.json)))

--- a/haskell-overlays/reflex-packages/dep/reflex-fsnotify/default.nix
+++ b/haskell-overlays/reflex-packages/dep/reflex-fsnotify/default.nix
@@ -1,7 +1,0 @@
-# DO NOT HAND-EDIT THIS FILE
-import ((import <nixpkgs> {}).fetchFromGitHub (
-  let json = builtins.fromJSON (builtins.readFile ./github.json);
-  in { inherit (json) owner repo rev sha256;
-       private = json.private or false;
-     }
-))

--- a/haskell-overlays/reflex-packages/dep/reflex-process/default.nix
+++ b/haskell-overlays/reflex-packages/dep/reflex-process/default.nix
@@ -1,7 +1,0 @@
-# DO NOT HAND-EDIT THIS FILE
-import ((import <nixpkgs> {}).fetchFromGitHub (
-  let json = builtins.fromJSON (builtins.readFile ./github.json);
-  in { inherit (json) owner repo rev sha256;
-       private = json.private or false;
-     }
-))

--- a/haskell-overlays/reflex-packages/dep/universe/default.nix
+++ b/haskell-overlays/reflex-packages/dep/universe/default.nix
@@ -1,7 +1,0 @@
-# DO NOT HAND-EDIT THIS FILE
-import ((import <nixpkgs> {}).fetchFromGitHub (
-  let json = builtins.fromJSON (builtins.readFile ./github.json);
-  in { inherit (json) owner repo rev sha256;
-       private = json.private or false;
-     }
-))


### PR DESCRIPTION
The thunk source repo not have a default.nix, so ‘import’ will not
work. Instead, users need to use hackGet.