### PR TITLE
Allow .attr-cache in hackGet

### DIFF
--- a/nixpkgs-overlays/hack-get/default.nix
+++ b/nixpkgs-overlays/hack-get/default.nix
@@ -11,9 +11,12 @@ self:
       filterArgs = x: removeAttrs x [ "branch" ];
       hasValidThunk = name: if builtins.pathExists (p + ("/" + name))
         then (let contents = builtins.readDir p;
-              in if contents == { ${name} = "regular"; } || contents == { ${name} = "regular"; "default.nix" = "regular"; }
+              in if contents == { ${name} = "regular"; } ||
+                    contents == { ${name} = "regular"; ".attr-cache" = "directory"; } ||
+                    contents == { ${name} = "regular"; "default.nix" = "regular"; } ||
+                    contents == { ${name} = "regular"; "default.nix" = "regular"; ".attr-cache" = "directory"; }
                  then true
-                 else throw "Thunk at ${toString p} has files in addition to ${name} and default.nix. Remove either ${name} or those other files to continue.")
+                 else throw "Thunk at ${toString p} has files in addition to ${name} and optionally default.nix and .attr-cache. Remove either ${name} or those other files to continue.")
         else false;
     in if hasValidThunk "git.json" then (
       let gitArgs = filterArgs (builtins.fromJSON (builtins.readFile (p + "/git.json")));


### PR DESCRIPTION
This is used by ob thunk to keep gc paths for nix. We need to support
this as well.

This probably can be made less complex, but for now we only have 4
cases to match. If we get more, it might make sense to make optional /
required matches more clear.