### PR TITLE
Make thunkSet ignore regular files

### DIFF
--- a/nixpkgs-overlays/hack-get/default.nix
+++ b/nixpkgs-overlays/hack-get/default.nix
@@ -48,5 +48,5 @@ self:
       };
 
   # Make an attribute set of source derivations for a directory containing thunks:
-  thunkSet = dir: lib.mapAttrs (name: _: self.hackGet (dir + "/${name}")) (builtins.readDir dir);
+  thunkSet = dir: lib.mapAttrs (name: _: self.hackGet (dir + "/${name}")) (lib.filterAttrs (_: type: type != "regular") (builtins.readDir dir));
 }

--- a/nixpkgs-overlays/hack-get/default.nix
+++ b/nixpkgs-overlays/hack-get/default.nix
@@ -48,5 +48,5 @@ self:
       };
 
   # Make an attribute set of source derivations for a directory containing thunks:
-  thunkSet = dir: lib.mapAttrs (name: _: self.hackGet (dir + "/${name}")) (lib.filterAttrs (_: type: type != "regular") (builtins.readDir dir));
+  thunkSet = dir: lib.mapAttrs (name: _: self.hackGet (dir + "/${name}")) (lib.filterAttrs (_: type: type == "directory" || type == "symlink") (builtins.readDir dir));
 }


### PR DESCRIPTION
`thunkSet` errors when there's, say, a README.md in the same dir as the thunks.