### PR TITLE
Allow altool in alternative location

### DIFF
--- a/ios/default.nix
+++ b/ios/default.nix
@@ -193,7 +193,7 @@ nixpkgs.runCommand "${executableName}-app" (rec {
     #!/usr/bin/env bash
     set -eo pipefail
 
-    if (( "$#" != 3 )); then
+    if [ "$#" -lt 3 ]; then
       echo "Usage: $0 [TEAM_ID] [IPA_DESTINATION] [EMBEDDED_PROVISIONING_PROFILE]" >&2
       exit 1
     fi

--- a/ios/default.nix
+++ b/ios/default.nix
@@ -245,7 +245,14 @@ nixpkgs.runCommand "${executableName}-app" (rec {
     /usr/bin/codesign --force --sign "$signer" --entitlements $tmpdir/xcent --timestamp=none "$tmpdir/${executableName}.app"
 
     /usr/bin/xcrun -sdk iphoneos ${./PackageApplication} -v "$tmpdir/${executableName}.app" -o "$IPA_DESTINATION" --sign "$signer" --embed "$EMBEDDED_PROVISIONING_PROFILE"
-    /Applications/Xcode.app/Contents/Applications/Application\ Loader.app/Contents/Frameworks/ITunesSoftwareService.framework/Versions/A/Support/altool --validate-app -f "$IPA_DESTINATION" -t ios "$@"
+
+    altool=/Applications/Xcode.app/Contents/Applications/Application\ Loader.app/Contents/Frameworks/ITunesSoftwareService.framework/Versions/A/Support/altool
+
+    if ! [ -x "$altool" ]; then
+      altool=/Applications/Xcode.app/Contents/Developer/usr/bin/altool
+    fi
+
+    "$altool" --validate-app -f "$IPA_DESTINATION" -t ios "$@"
   '';
   runInSim = builtins.toFile "run-in-sim" ''
     #!/usr/bin/env bash


### PR DESCRIPTION
On newer Xcode, altool resides in
/Applications/Xcode.app/Contents/Developer/usr/bin/altool. Keeping the
old location for compatibility.