### PR TITLE
Choose iOS simulator runtime based on supported devices

### DIFF
--- a/scripts/run-in-ios-sim
+++ b/scripts/run-in-ios-sim
@@ -11,8 +11,12 @@ if [ "$#" = 2 ]; then
   bundleIdentifier="$2"
 fi
 
-runtime="$(xcrun simctl list runtimes -j | jq -r '.runtimes[].identifier' | head -n1)"
+# Choose the first runtime which allows simulation of an iPhone 8
+runtime="$(xcrun simctl list devices -j | jq -r '.devices | to_entries[] | (.key as $k | .value[] | if .isAvailable and .name == "iPhone 8" then $k else empty end)' | sort | head -n1)"
+echo "Using runtime $runtime"
+echo "Creating device $name"
 uuid="$(xcrun simctl create "$name" com.apple.CoreSimulator.SimDeviceType.iPhone-8 "$runtime")"
+echo "Device UUID $uuid"
 
 function cleanup {
   if [ -n "$uuid" ]; then


### PR DESCRIPTION
Without this change, we would often choose a runtime which does not support a particular device, for example trying iOS 10 on with an iPhone 8, when iOS 11 is the minimum supported version.