### PR TITLE
Fix pure nix evaluation of nixpkgs-old-chromium

### DIFF
--- a/haskell-overlays/reflex-packages/default.nix
+++ b/haskell-overlays/reflex-packages/default.nix
@@ -20,7 +20,7 @@ let
 
   inherit (nixpkgs) stdenv;
   # Older chromium for reflex-dom-core test suite
-  nixpkgs_oldChromium = import ../../nixpkgs-old-chromium { inherit (nixpkgs.stdenv) system; };
+  nixpkgs_oldChromium = import ../../nixpkgs-old-chromium { inherit (nixpkgs.stdenv.buildPlatform) system; };
 in
 {
   _dep = super._dep or {} // thunkSet ./dep;

--- a/haskell-overlays/reflex-packages/default.nix
+++ b/haskell-overlays/reflex-packages/default.nix
@@ -20,7 +20,7 @@ let
 
   inherit (nixpkgs) stdenv;
   # Older chromium for reflex-dom-core test suite
-  nixpkgs_oldChromium = import ../../nixpkgs-old-chromium {};
+  nixpkgs_oldChromium = import ../../nixpkgs-old-chromium { inherit (nixpkgs) system; };
 in
 {
   _dep = super._dep or {} // thunkSet ./dep;

--- a/haskell-overlays/reflex-packages/default.nix
+++ b/haskell-overlays/reflex-packages/default.nix
@@ -20,7 +20,7 @@ let
 
   inherit (nixpkgs) stdenv;
   # Older chromium for reflex-dom-core test suite
-  nixpkgs_oldChromium = import ../../nixpkgs-old-chromium { inherit (nixpkgs) system; };
+  nixpkgs_oldChromium = import ../../nixpkgs-old-chromium { inherit (nixpkgs.stdenv) system; };
 in
 {
   _dep = super._dep or {} // thunkSet ./dep;


### PR DESCRIPTION
Running nix in pure mode results in an error in the evaluation of nixpkgs-old-chromium, 
namely 'attribute builtins.currentSystem missing', because the system argument is not explicitely passed.

This change passes the system argument explicitely, so that it is possible to run nix in pure mode.