### PR TITLE
haskell-overlays: reflex-dom-core -> 0.7.0.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -24,6 +24,8 @@ This project's release branch is `master`. This log is written from the perspect
   * beam-migrate to 0.5.1.0
   * beam-postgres to 0.5.1.0
   * pandoc to 2.16.2
+* New pins
+  * ghcjs-promise 0.1.0.3
 
 ## v0.9.0.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,12 @@
 
 This project's release branch is `master`. This log is written from the perspective of the release branch: when changes hit `master`, they are considered released.
 
+## v0.9.2.0
+
+* Bump
+  * [reflex-dom-core to 0.7.0.0](https://github.com/reflex-frp/reflex-dom/releases/tag/reflex-dom-core-0.7.0.0).
+  * reflex-dom to 0.6.1.1-r1
+
 ## v0.9.1.0
 
 * Add a partial preview of GHC 8.10 support, not on by default.

--- a/haskell-overlays/reflex-packages/dep/reflex-dom/github.json
+++ b/haskell-overlays/reflex-packages/dep/reflex-dom/github.json
@@ -1,8 +1,8 @@
 {
   "owner": "reflex-frp",
   "repo": "reflex-dom",
-  "branch": "release/reflex-dom/0.6.1.1",
+  "branch": "aa/remove-hasjscontext",
   "private": false,
-  "rev": "05d8bf4d7f9ce9da39669cd0d6e03c06b0691aab",
-  "sha256": "17njzfbmfwdfz7l0y36qw0yqpjax4bbmpgrmdbyxh13a8vz82an4"
+  "rev": "de85e850d529ceebd77e9cd9124e5b9b83cf2120",
+  "sha256": "04lrdhfkbk4nlj2lw7q96apjqmdydqafpylf10qgpjzpvn9la278"
 }

--- a/haskell-overlays/untriaged.nix
+++ b/haskell-overlays/untriaged.nix
@@ -52,4 +52,6 @@ self: super: {
   cryptohash-sha512 = doJailbreak super.cryptohash-sha512;
   ListLike = self.callHackage "ListLike" "4.7.3" {};
 
+  # ghcjs-promise is marked broken in nixpkgs
+  ghcjs-promise = self.callHackage "ghcjs-promise" "0.1.0.3" {};
 }


### PR DESCRIPTION
This removes HasJSContexts, HasJS, and changes `Prerender js t m` to `Prerender t m`.