### PR TITLE
Always use GHC 8.10.7, not GHC 8.10.4

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,11 @@ This project's release branch is `master`. This log is written from the perspect
 
 ## Unreleased
 
+* Always use GHC 8.10.7, not GHC 8.10.4, for GHC 8.10.
+  Previously we were using mixed GHC 8.10 versions to avoid issues.
+
+## Unreleased
+
 * GHC 8.10 support is complete, with the remaining profiling builds
   that worked for 8.6 (everything but GHCJS's) now also working for 8.10.
 

--- a/default.nix
+++ b/default.nix
@@ -45,7 +45,7 @@ let iosSupport = system == "x86_64-darwin";
             # from the src proper.
             patches = [];
           });
-          ghcSplices-8_10 = (super.haskell.compiler.ghc8104.override {
+          ghcSplices-8_10 = (super.haskell.compiler.ghc8107.override {
             # New option for GHC 8.10. Explicitly enable profiling builds
             enableProfiledLibs = true;
           }).overrideAttrs (drv: {
@@ -68,7 +68,7 @@ let iosSupport = system == "x86_64-darwin";
             buildHaskellPackages = self.buildPackages.haskell.packages.ghcSplices-8_6;
             ghc = self.buildPackages.haskell.compiler.ghcSplices-8_6;
           };
-          ghcSplices-8_10 = super.haskell.packages.ghc8104.override {
+          ghcSplices-8_10 = super.haskell.packages.ghc8107.override {
             buildHaskellPackages = self.buildPackages.haskell.packages.ghcSplices-8_10;
             ghc = self.buildPackages.haskell.compiler.ghcSplices-8_10;
           };
@@ -266,7 +266,7 @@ let iosSupport = system == "x86_64-darwin";
   ghcHEAD = (makeRecursivelyOverridable nixpkgs.haskell.packages.ghcHEAD).override {
     overrides = nixpkgs.haskell.overlays.combined;
   };
-  ghc8_10 = (makeRecursivelyOverridable nixpkgs.haskell.packages.ghc8104).override {
+  ghc8_10 = (makeRecursivelyOverridable nixpkgs.haskell.packages.ghc8107).override {
     overrides = nixpkgs.haskell.overlays.combined;
   };
   ghc8_6 = (makeRecursivelyOverridable nixpkgs.haskell.packages.ghc865).override {

--- a/nixpkgs-overlays/mobile-ghc/default.nix
+++ b/nixpkgs-overlays/mobile-ghc/default.nix
@@ -5,6 +5,6 @@ self: super: {
       patches = (drv.patches or []) ++ lib.optionals self.stdenv.targetPlatform.useAndroidPrebuilt [
         ./8.6.y/android-patches/force-relocation.patch
       ];
-    })) { inherit (super.haskell.compiler) ghc865 ghcSplices-8_6 ghc8104 ghcSplices-8_10; };
+    })) { inherit (super.haskell.compiler) ghc865 ghcSplices-8_6 ghc8107 ghcSplices-8_10; };
   };
 }


### PR DESCRIPTION
Previously we were using mixed GHC 8.10 versions to avoid issues.