### PR TITLE
Fix SIGBUS crashes on armv7a due unaligned writes

### DIFF
--- a/nixpkgs-overlays/mobile-ghc/8.6.y/android-patches/strict-align.patch
+++ b/nixpkgs-overlays/mobile-ghc/8.6.y/android-patches/strict-align.patch
@@ -1,0 +1,24 @@
+diff --git a/libraries/bytestring/Data/ByteString/Builder/Prim/Internal.hs b/libraries/bytestring/Data/ByteString/Builder/Prim/Internal.hs
+index fb52404..572b4b7 100644
+--- a/libraries/bytestring/Data/ByteString/Builder/Prim/Internal.hs
++++ b/libraries/bytestring/Data/ByteString/Builder/Prim/Internal.hs
+@@ -198,7 +198,19 @@ liftFixedToBounded = toB
+ 
+ {-# INLINE CONLIKE storableToF #-}
+ storableToF :: forall a. Storable a => FixedPrim a
++-- Not all architectures are forgiving of unaligned accesses; whitelist ones
++-- which are known not to trap (either to the kernel for emulation, or crash).
++#if defined(i386_HOST_ARCH) || defined(x86_64_HOST_ARCH) \
++    || ((defined(arm_HOST_ARCH) || defined(aarch64_HOST_ARCH)) \
++        && defined(__ARM_FEATURE_UNALIGNED)) \
++    || defined(powerpc_HOST_ARCH) || defined(powerpc64_HOST_ARCH) \
++    || defined(powerpc64le_HOST_ARCH)
+ storableToF = FP (sizeOf (undefined :: a)) (\x op -> poke (castPtr op) x)
++#else
++storableToF = FP (sizeOf (undefined :: a)) $ \x op ->
++    if ptrToWordPtr op `mod` fromIntegral (alignment (undefined :: a)) == 0 then poke (castPtr op) x
++    else with x $ \tp -> copyBytes op (castPtr tp) (sizeOf (undefined :: a))
++#endif
+ 
+ {-
+ {-# INLINE CONLIKE liftIOF #-}

--- a/nixpkgs-overlays/mobile-ghc/default.nix
+++ b/nixpkgs-overlays/mobile-ghc/default.nix
@@ -4,6 +4,7 @@ self: super: {
     compiler = super.haskell.compiler // lib.mapAttrs (n: v: v.overrideAttrs (drv: {
       patches = (drv.patches or []) ++ lib.optionals self.stdenv.targetPlatform.useAndroidPrebuilt [
         ./8.6.y/android-patches/force-relocation.patch
+        ./8.6.y/android-patches/strict-align.patch
       ];
     })) { inherit (super.haskell.compiler) ghc865 ghcSplices-8_6 ghc8107 ghcSplices-8_10; };
   };


### PR DESCRIPTION
Hi, I recently got an old android smartphone (LG K8 Android 6.0) as users started to filling reports about crashes on that device for [our app](https://github.com/hexresearch/ergvein). Ages of ineffective debug showed that crashes were caused by `Data.ByteString.Builder` any time when I tried to serialize some network messages. 

Crash logs usually contains only records with: 
```
03-25 10:39:15.639 14487 14487 F libc    : Fatal signal 6 (SIGABRT), code -6 in tid 14487 (.ergvein.wallet)
03-25 10:39:15.650   645   645 D AEE/AED : $===AEE===AEE===AEE===$
03-25 10:39:15.651   645   645 D AEE/AED : p 0 poll events 1 revents 0
03-25 10:39:15.651   645   645 D AEE/AED : not know revents:0
03-25 10:39:15.651   645   645 D AEE/AED : p 1 poll events 1 revents 0
03-25 10:39:15.651   645   645 D AEE/AED : not know revents:0
03-25 10:39:15.651   645   645 D AEE/AED : p 2 poll events 1 revents 1
03-25 10:39:15.651   645   645 D AEE/AED : aed_main_fork_worker: generator 0xb7a5e1b8, worker 0xbed93938, recv_fd 0
03-25 10:39:15.652   645   645 D AEE/AED : p 3 poll events 1 revents 0
03-25 10:39:15.652   645   645 D AEE/AED : not know revents:0
03-25 10:39:15.652   645   645 D AEE/AED : p 4 poll events 1 revents 0
03-25 10:39:15.652   645   645 D AEE/AED : not know revents:0
03-25 10:39:15.652   645   645 D AEE/AED : p 5 poll events 0 revents 0
03-25 10:39:15.652   645   645 D AEE/AED : not know revents:0
03-25 10:39:15.652 14596 14596 I AEE/AED : handle_request(0)
03-25 10:39:15.654 14596 14596 I AEE/AED : check process 14487 name:.ergvein.wallet
03-25 10:39:15.654 14596 14596 I AEE/AED : tid 14487 abort msg address is:0xb3955000, si_code is:0 (request from -6:14487)
03-25 10:39:15.654 14596 14596 I AEE/AED : BOOM: pid=14487 uid=10137 gid=10137 tid=14487
03-25 10:39:15.655 14596 14596 I AEE/AED : [OnPurpose Redunant in void preset_info(aed_report_record*, int, int)] pid: 14487, tid: 14487, name: .ergvein.wallet  >>> org.ergvein.wallet <<<
03-25 10:39:15.713 14596 14596 F AEE/DEBUG: *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
03-25 10:39:15.713 14596 14596 F AEE/DEBUG: Build fingerprint: 'lge/mm1v_global_com/mm1v:6.0/MRA58K/190931932f506:user/release-keys'
03-25 10:39:15.713 14596 14596 F AEE/DEBUG: Revision: '1.0'
03-25 10:39:15.713 14596 14596 F AEE/DEBUG: ABI: 'arm'
03-25 10:39:15.713 14596 14596 F AEE/DEBUG: pid: 14487, tid: 14487, name: .ergvein.wallet  >>> org.ergvein.wallet <<<
03-25 10:39:15.713 14596 14596 F AEE/DEBUG: signal 6 (SIGABRT), code -6 (SI_TKILL), fault addr --------
03-25 10:39:15.755 14596 14596 F AEE/DEBUG: Abort message: 'cbits/dnsdetector.c:27: const char *android_detectdns(jobject): assertion "resStrObj" failed'
03-25 10:39:15.755 14596 14596 F AEE/DEBUG:     r0 00000000  r1 00003897  r2 00000006  r3 b6fd4e2c
03-25 10:39:15.756 14596 14596 F AEE/DEBUG:     r4 b6fd4e34  r5 b6fd4de4  r6 00000000  r7 0000010c
03-25 10:39:15.756 14596 14596 F AEE/DEBUG:     r8 9b2692a0  r9 00000000  sl 9f93ec90  fp beccdf80
03-25 10:39:15.756 14596 14596 F AEE/DEBUG:     ip 00000006  sp beccdee0  lr b6d4eeed  pc b6d50dec  cpsr 400f0010
03-25 10:39:15.956 14596 14596 F AEE/DEBUG: 
03-25 10:39:15.956 14596 14596 F AEE/DEBUG: backtrace:
03-25 10:39:15.956 14596 14596 F AEE/DEBUG:     #00 pc 00043dec  /system/lib/libc.so (tgkill+12)
03-25 10:39:15.957 14596 14596 F AEE/DEBUG:     #01 pc 00041ee9  /system/lib/libc.so (pthread_kill+32)
03-25 10:39:15.957 14596 14596 F AEE/DEBUG:     #02 pc 0001bb4f  /system/lib/libc.so (raise+10)
03-25 10:39:15.957 14596 14596 F AEE/DEBUG:     #03 pc 00018d01  /system/lib/libc.so (__libc_android_abort+34)
03-25 10:39:15.957 14596 14596 F AEE/DEBUG:     #04 pc 000168c0  /system/lib/libc.so (abort+4)
03-25 10:39:15.957 14596 14596 F AEE/DEBUG:     #05 pc 0001a763  /system/lib/libc.so (__libc_fatal+16)
03-25 10:39:15.957 14596 14596 F AEE/DEBUG:     #06 pc 00018d89  /system/lib/libc.so (__assert2+20)
03-25 10:39:15.957 14596 14596 F AEE/DEBUG:     #07 pc 008286b0  /data/app/org.ergvein.wallet-1/lib/arm/libHaskellActivity.so (android_detectdns+532)
```

So, I back ported patch from https://github.com/haskell/bytestring/pull/232 to prevent `bytestring` from writing with violation of strict alignment of memory. I hope that the patch may help someone to save a week of their life >_<