### PR TITLE
Include lib, exe flags with cabal init instruction

### DIFF
--- a/docs/project-development.rst
+++ b/docs/project-development.rst
@@ -55,12 +55,12 @@ see a better way to get the ``cabal`` command later.
 .. code:: bash
 
    $ mkdir common backend frontend
-   $ (cd common && cabal init)
-   $ (cd backend && cabal init)
-   $ (cd frontend && cabal init)
+   $ (cd common && cabal init --lib)
+   $ (cd backend && cabal init --exe)
+   $ (cd frontend && cabal init --exe)
 
-This will prompt for various bits of metadata. ``common`` should be a
-library, and ``frontend`` and ``backend`` should be executables. These
+This will create ``common`` as a
+library, and ``frontend`` and ``backend`` as executables. These
 cabal files are where the dependencies and build targets of each Haskell
 component can be described.
 


### PR DESCRIPTION
The previous version states that `cabal init` will prompt the user for metadata, but I found that this didn't happen. Using the optional flags did what I expected. It seems like explicitly specifying them would be the more stable thing to do anyway.