### PR TITLE
Fix sample code that fails to compile

### DIFF
--- a/docs/project-development.rst
+++ b/docs/project-development.rst
@@ -87,6 +87,7 @@ Finally, Nix will fail to build ``common`` if it exports no modules.
    ...
    # common/common.cabal
    library
+     hs-source-dirs: src
      build-depends: base
      exposed-modules: Common
    ...


### PR DESCRIPTION
requires setting "hs-source-dirs: src"