### PR TITLE
Fix double dip of path in hack-on script

### DIFF
--- a/scripts/hack-on
+++ b/scripts/hack-on
@@ -6,15 +6,16 @@ DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )
 . "$DIR/scripts/common-setup.sh"
 
 REPO="$(echo "$1" | sed 's_/$__')"
+BASE="$(basename $REPO)"
 
 if [ ! -d "$REPO" ] ; then
     echo "Error: no such directory: $REPO"
     exit 1
 fi
 
-DIFF="$(git -C "$REPO/.." diff HEAD -- "$REPO")"
+DIFF="$(git -C "$REPO/.." diff HEAD -- "$BASE")"
 DIFF_ERR=$?
-STATUS="$(git -C "$REPO/.." status --porcelain --ignored "$REPO")"
+STATUS="$(git -C "$REPO/.." status --porcelain --ignored "$BASE")"
 STATUS_ERR=$?
 
 if [ "$DIFF_ERR" -ne 0 -o "$STATUS_ERR" -ne 0 ] ; then


### PR DESCRIPTION
Without this change, `hack-on` issues a suspicious `warning: could not open directory`:

```bash
$ ./scripts/hack-on haskell-overlays/reflex-packages/dep/reflex
If you have any trouble with this script, please submit an issue at https://github.com/reflex-frp/reflex-platform/issues
#1-NixOS SMP PREEMPT_DYNAMIC Fri Jul 29 15:28:18 UTC 2022
Please enable reflex's binary cache by following the instructions at https://github.com/reflex-frp/reflex-platform/blob/develop/notes/NixOS.md
warning: could not open directory 'haskell-overlays/reflex-packages/dep/haskell-overlays/reflex-packages/dep/': No such file or directory
Checking out https://github.com/reflex-frp/reflex at revision d9a40cd97072869c91479303ee52577b793c11d2
Cloning into 'haskell-overlays/reflex-packages/dep/reflex'...
Note: switching to 'd9a40cd97072869c91479303ee52577b793c11d2'.
....
```

though it _seems_ to succeed. 
However, the safeguard diffing is broken as we can see if we repeat the command now that the directory has had its contents messed with:

```bash
$ ./scripts/hack-on haskell-overlays/reflex-packages/dep/reflex
If you have any trouble with this script, please submit an issue at https://github.com/reflex-frp/reflex-platform/issues
#1-NixOS SMP PREEMPT_DYNAMIC Fri Jul 29 15:28:18 UTC 2022
Please enable reflex's binary cache by following the instructions at https://github.com/reflex-frp/reflex-platform/blob/develop/notes/NixOS.md
warning: could not open directory 'haskell-overlays/reflex-packages/dep/haskell-overlays/reflex-packages/dep/': No such file or directory
./scripts/hack-on: line 42: URL: unbound variable
```

With this change, we no longer get the warning from a clean state and get the intended behavior on a repeated invocatoin.
```bash
$  ./scripts/hack-on haskell-overlays/reflex-packages/dep/reflex
...
Error: haskell-overlays/reflex-packages/dep/reflex contains unsaved modifications
```

Bug present since, huh, always: https://github.com/reflex-frp/reflex-platform/commit/aaecde2e716bf05dff8e9393746161f158311148
The reason it wasn't caught back then is that the thunks were all top-level, so we had `$(basename $x) = $x`. We can see in the original commit that tests were added, and they seem to still be using the top-level dirs
https://github.com/reflex-frp/reflex-platform/blob/0309a7bf2591cc622737ba54809026e51cfeb57f/scripts/test.hs#L77-L78
 so I'm guessing `./scripts/test` hasn't been ran in a long time (possibly ever since we moved off circleci) even though https://github.com/reflex-frp/reflex-platform/blob/develop/CONTRIBUTING.md mentions it?
