### PR TITLE
Revert "reflex-dom-core: disable tests to fix determinism"

### DIFF
--- a/haskell-overlays/reflex-packages/default.nix
+++ b/haskell-overlays/reflex-packages/default.nix
@@ -49,7 +49,6 @@ in
   reflex-todomvc = self.callPackage self._dep.reflex-todomvc {};
   reflex-aeson-orphans = self.callCabal2nix "reflex-aeson-orphans" self._dep.reflex-aeson-orphans {};
 
-  # The tests for reflex-dom-core are not deterministic, disable them, and run them manually
   reflex-dom-core = let
     inherit (self) ghc;
     noGcTest = stdenv.hostPlatform.system != "x86_64-linux"
@@ -60,13 +59,11 @@ in
       reflexOptimizerFlag
       useTemplateHaskellFlag
       (lib.optional enableLibraryProfiling "-fprofile-reflex")
-      [ "-f-hydration-tests" ]
-      [ "-f-gc-tests" ]
     ])) {})
     (drv: {
       # TODO: Get hlint working for cross-compilation
-      #doCheck = stdenv.hostPlatform == stdenv.buildPlatform && !(ghc.isGhcjs or false);
-      doCheck = false;
+      doCheck = stdenv.hostPlatform == stdenv.buildPlatform && !(ghc.isGhcjs or false);
+
       # The headless browser run as part of the tests will exit without this
       preBuild = (drv.preBuild or "") + ''
         export HOME="$PWD"


### PR DESCRIPTION
We should look at the actual error and fix it. There are some hard coded wait times in the tests, if they're causing the failure we can increase them somewhat. AFAICT candidates functions to adjust are `withSeleniumServer` and `withRetry`.

Running the `gc` test with `cpulimit -l 1` results in:
```
...
438664
436864
440056
SUCCEEDED
[0207/130124.616315:ERROR:broker_posix.cc(40)] Recvmsg error:
Connection reset by peer (104)
```
which may also be considered a failure by the test suite.

This reverts commit f9a54be4fe65f1fed1e22d0abd186e63233fb21a.