### PR TITLE
Bump targetSdk for Android

### DIFF
--- a/android/AndroidManifest.xml.nix
+++ b/android/AndroidManifest.xml.nix
@@ -27,6 +27,7 @@ in ''
                   android:label="@string/app_name"
                   android:configChanges="orientation|screenSize"
                   android:windowSoftInputMode="adjustResize"
+                  android:exported="true"
                   ${activityAttributes}
                   >
             <intent-filter>

--- a/android/build.gradle.nix
+++ b/android/build.gradle.nix
@@ -70,7 +70,7 @@ android {
     defaultConfig {
         applicationId "${applicationId}"
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode ${version.code}
         versionName "${version.name}"
         multiDexEnabled false

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,8 @@
 { nixpkgsFunc ? import ./nixpkgs
 , system ? builtins.currentSystem
-, config ? {}
+, config ? {
+  android_sdk.accept_license = true;
+}
 , enableLibraryProfiling ? false
 , enableExposeAllUnfoldings ? true
 , enableTraceReflexEvents ? false
@@ -170,6 +172,7 @@ let iosSupport = system == "x86_64-darwin";
         aarch64 = {
           crossSystem = lib.systems.examples.aarch64-android-prebuilt //
           { isStatic = true; };
+          sdkVer = "31";
         };
         aarch32 = {
           crossSystem = lib.systems.examples.armv7a-android-prebuilt // {

--- a/default.nix
+++ b/default.nix
@@ -1,8 +1,6 @@
 { nixpkgsFunc ? import ./nixpkgs
 , system ? builtins.currentSystem
-, config ? {
-  android_sdk.accept_license = true;
-}
+, config ? { }
 , enableLibraryProfiling ? false
 , enableExposeAllUnfoldings ? true
 , enableTraceReflexEvents ? false


### PR DESCRIPTION
Google Play now requires new apps be on SDK 31 or higher

(Forces targeting SDK 33 in August, 2023); SDK 31 is fine for now