### PR TITLE
Bump `dependent-sum` and `dependent-sum-template`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,13 @@
 
 This project's release branch is `master`. This log is written from the perspective of the release branch: when changes hit `master`, they are considered released.
 
+## Unreleased
+
+* Bump `some` to 1.0.4
+* Bump `dependent-sum-template` to 0.1.2.0
+
+(The thunk for `dependent-sum` is also changed, but there is no corresponding code change so the version is the same. This is just part of separating it from `dependent-sum-template`.)
+
 ## v1.0.1.0
 
 * iOS: Bump SDK version from 15.0 -> 16.1

--- a/haskell-overlays/reflex-packages/default.nix
+++ b/haskell-overlays/reflex-packages/default.nix
@@ -195,8 +195,8 @@ in
   aeson-gadt-th = self.callHackage "aeson-gadt-th" "0.2.5.1" {};
   dependent-map = self.callCabal2nix "dependent-map" (hackGet ./dep/dependent-map) {};
   dependent-monoidal-map = self.callCabal2nix "dependent-monoidal-map" self._dep.dependent-monoidal-map {};
-  dependent-sum = self.callCabal2nix "dependent-sum" (hackGet ./dep/dependent-sum + "/dependent-sum") {};
-  dependent-sum-template = self.callCabal2nix "dependent-sum-template" (hackGet ./dep/dependent-sum + "/dependent-sum-template") {};
+  dependent-sum = self.callCabal2nix "dependent-sum" self._dep.dependent-sum {};
+  dependent-sum-template = self.callCabal2nix "dependent-sum-template" self._dep.dependent-sum-template {};
   dependent-sum-universe-orphans = self.callCabal2nix "dependent-sum-universe-orphans" self._dep.dependent-sum-universe-orphans {};
   dependent-sum-aeson-orphans = self.callCabal2nix "dependent-sum-aeson-orphans" self._dep.dependent-sum-aeson-orphans {};
 

--- a/haskell-overlays/reflex-packages/default.nix
+++ b/haskell-overlays/reflex-packages/default.nix
@@ -190,7 +190,7 @@ in
   }) {};
 
   constraints-extras = self.callCabal2nix "constraints-extras" (hackGet ./dep/constraints-extras) {};
-  some = self.callHackage "some" "1.0.2" {};
+  some = self.callHackage "some" "1.0.4" {};
   prim-uniq = self.callHackage "prim-uniq" "0.2" {};
   aeson-gadt-th = self.callHackage "aeson-gadt-th" "0.2.5.1" {};
   dependent-map = self.callCabal2nix "dependent-map" (hackGet ./dep/dependent-map) {};

--- a/haskell-overlays/reflex-packages/dep/dependent-sum-template/default.nix
+++ b/haskell-overlays/reflex-packages/dep/dependent-sum-template/default.nix
@@ -1,0 +1,2 @@
+# DO NOT HAND-EDIT THIS FILE
+import (import ./thunk.nix)

--- a/haskell-overlays/reflex-packages/dep/dependent-sum-template/github.json
+++ b/haskell-overlays/reflex-packages/dep/dependent-sum-template/github.json
@@ -1,0 +1,8 @@
+{
+  "owner": "obsidiansystems",
+  "repo": "dependent-sum-template",
+  "branch": "develop",
+  "private": false,
+  "rev": "d05995c05d62751817c3d75f86ac345b16d529be",
+  "sha256": "1dvvsawnc1w60r2c9ix4p8idbi0dpb223ffvh6662fa2qzwmijp7"
+}

--- a/haskell-overlays/reflex-packages/dep/dependent-sum-template/github.json
+++ b/haskell-overlays/reflex-packages/dep/dependent-sum-template/github.json
@@ -1,8 +1,8 @@
 {
   "owner": "obsidiansystems",
   "repo": "dependent-sum-template",
-  "branch": "develop",
+  "branch": "master",
   "private": false,
-  "rev": "d05995c05d62751817c3d75f86ac345b16d529be",
+  "rev": "2204b5dbb8eec475b4b8db4b2ef51c761bfdf209",
   "sha256": "1dvvsawnc1w60r2c9ix4p8idbi0dpb223ffvh6662fa2qzwmijp7"
 }

--- a/haskell-overlays/reflex-packages/dep/dependent-sum-template/thunk.nix
+++ b/haskell-overlays/reflex-packages/dep/dependent-sum-template/thunk.nix
@@ -1,0 +1,12 @@
+# DO NOT HAND-EDIT THIS FILE
+let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
+  if !fetchSubmodules && !private then builtins.fetchTarball {
+    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
+  } else (import (builtins.fetchTarball {
+  url = "https://github.com/NixOS/nixpkgs/archive/3aad50c30c826430b0270fcf8264c8c41b005403.tar.gz";
+  sha256 = "0xwqsf08sywd23x0xvw4c4ghq0l28w2ki22h0bdn766i16z9q2gr";
+}) {}).fetchFromGitHub {
+    inherit owner repo rev sha256 fetchSubmodules private;
+  };
+  json = builtins.fromJSON (builtins.readFile ./github.json);
+in fetch json

--- a/haskell-overlays/reflex-packages/dep/dependent-sum/github.json
+++ b/haskell-overlays/reflex-packages/dep/dependent-sum/github.json
@@ -1,8 +1,8 @@
 {
   "owner": "obsidiansystems",
   "repo": "dependent-sum",
-  "branch": "bump-constraints-extras",
+  "branch": "develop",
   "private": false,
-  "rev": "619727ba1792e39a68d23c62e75a923672e87a54",
-  "sha256": "0r86aqvdkfi1s75va0i8q0kcx989qx9q4cypgy4sl5db8q983pic"
+  "rev": "b066b509021d2db13564fa1519ea7de20a8d206c",
+  "sha256": "1pmw2n3xxjz22yqbdnnmrh6yfg50p6n4v2ji0iww1ml8prc3gqfq"
 }


### PR DESCRIPTION
We were previously missing the latest version of
`dependent-sum-template` due to confusion over them being in the same repo. Now, they are split into separate repos again, something which reduces cognitive overhead *and* is now safe because neither dependson the other. (They both instead depend on `some`.)

We want to release both, so making this PR to CI everything with the release candidates. If this passes, we will cut release and them bump the thunks again to point to `master` not `develop`.