### PR TITLE
Update to target 31, Google Play store requires this is the target for apps after 2021

### DIFF
--- a/android/build.gradle.nix
+++ b/android/build.gradle.nix
@@ -44,7 +44,7 @@ allprojects {
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     buildToolsVersion '30.0.2'
 
     lintOptions {
@@ -70,7 +70,7 @@ android {
     defaultConfig {
         applicationId "${applicationId}"
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode ${version.code}
         versionName "${version.name}"
         multiDexEnabled false

--- a/android/impl.nix
+++ b/android/impl.nix
@@ -36,7 +36,7 @@ in {
     keyStore = releaseKey.storeFile or null;
     keyStorePassword = releaseKey.storePassword or null;
     name = applicationId;
-    platformVersions = [ "30" ];
+    platformVersions = [ "31" ];
     release = false;
     src =
       let splitApplicationId = splitString "." applicationId;


### PR DESCRIPTION
This will increase to needing to target 33 very soon (August 2023), which will require actual work on reflex-platform.

[Here are the changes necessary later on](https://developer.android.com/about/versions/13/behavior-changes-13)

For now though, this is enough